### PR TITLE
Make matplotlib an optional dependency

### DIFF
--- a/ruptures/show/display.py
+++ b/ruptures/show/display.py
@@ -49,15 +49,13 @@ from itertools import cycle
 
 import numpy as np
 
-try:
-    import matplotlib.pyplot as plt
-    matplotlib_is_installed = True
-except ImportError:
-    matplotlib_is_installed = False
-
 from ruptures.utils import pairwise
 
 COLOR_CYCLE = ["#4286f4", "#f44174"]
+
+
+class MatplotlibMissingError(RuntimeError):
+    pass
 
 
 def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
@@ -74,9 +72,12 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
         tuple: (figure, axarr) with a :class:`matplotlib.figure.Figure` object and an array of Axes objects.
 
     """
-    if not matplotlib_is_installed:
-        raise RuntimeError(
-            'This features requires the optional dependency matpotlib, you can install it using `pip install matplotlib`.')
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise MatplotlibMissingError(
+            'This feature requires the optional dependency matpotlib, you can install it using `pip install matplotlib`.')
+
     if type(signal) != np.ndarray:
         # Try to get array from Pandas dataframe
         signal = signal.values

--- a/ruptures/show/display.py
+++ b/ruptures/show/display.py
@@ -47,8 +47,13 @@ Code explanation
 
 from itertools import cycle
 
-import matplotlib.pyplot as plt
 import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+    matplotlib_is_installed = True
+except ImportError:
+    matplotlib_is_installed = False
 
 from ruptures.utils import pairwise
 
@@ -69,6 +74,9 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
         tuple: (figure, axarr) with a :class:`matplotlib.figure.Figure` object and an array of Axes objects.
 
     """
+    if not matplotlib_is_installed:
+        raise RuntimeError(
+            'This features requires the optional dependency matpotlib, you can install it using `pip install matplotlib`.')
     if type(signal) != np.ndarray:
         # Try to get array from Pandas dataframe
         signal = signal.values

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ setup(
     name='ruptures',
     version='1.0a1',
     packages=find_packages(exclude=['docs', 'tests*', 'images']),
-    install_requires=['numpy', 'scipy', 'matplotlib'],
+    install_requires=['numpy', 'scipy'],
+    extras_require={
+        'display': ['matplotlib']
+    },
     python_requires='>=3',
     # url='ctruong.perso.math.cnrs.fr/ruptures',
     license='BSD License',

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,8 @@
+import pytest
+
 from ruptures.datasets import pw_constant
 from ruptures.show import display
-from ruptures.show.display import matplotlib_is_installed
-import pytest
+from ruptures.show.display import MatplotlibMissingError
 
 
 @pytest.fixture(scope="module")
@@ -11,17 +12,18 @@ def signal_bkps():
 
 
 def test_display(signal_bkps):
-    if not matplotlib_is_installed:
+    try:
+        signal, bkps = signal_bkps
+        fig, axarr = display(signal, bkps)
+        fig, axarr = display(signal, bkps, bkps)
+        figsize = (20, 10)  # figure size
+        alpha = 0.2
+        color = "k"
+        linewidth = 3
+        linestyle = "--"
+        fig, axarr = display(signal, bkps, figsize=figsize, alpha=alpha,
+                             color=color, linewidth=linewidth, linestyle=linestyle)
+        fig, axarr = display(signal[:, 0], bkps, figsize=figsize, alpha=alpha,
+                             color=color, linewidth=linewidth, linestyle=linestyle)
+    except MatplotlibMissingError:
         pytest.skip('matplotlib is not installed')
-    signal, bkps = signal_bkps
-    fig, axarr = display(signal, bkps)
-    fig, axarr = display(signal, bkps, bkps)
-    figsize = (20, 10)  # figure size
-    alpha = 0.2
-    color = "k"
-    linewidth = 3
-    linestyle = "--"
-    fig, axarr = display(signal, bkps, figsize=figsize, alpha=alpha,
-                         color=color, linewidth=linewidth, linestyle=linestyle)
-    fig, axarr = display(signal[:, 0], bkps, figsize=figsize, alpha=alpha,
-                         color=color, linewidth=linewidth, linestyle=linestyle)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,6 @@
 from ruptures.datasets import pw_constant
 from ruptures.show import display
+from ruptures.show.display import matplotlib_is_installed
 import pytest
 
 
@@ -10,6 +11,8 @@ def signal_bkps():
 
 
 def test_display(signal_bkps):
+    if not matplotlib_is_installed:
+        pytest.skip('matplotlib is not installed')
     signal, bkps = signal_bkps
     fig, axarr = display(signal, bkps)
     fig, axarr = display(signal, bkps, bkps)


### PR DESCRIPTION
Hi,

Matplotlib is sometimes hard to install in server and headless setups.

Since it's not required to use the main part of the library, I think it makes sense to make it optional.

I'm open to suggestions if there is a better way to implement this functionality.

In the meantime, I've pushed the fork to pypi as [ruptures-headless](https://pypi.org/project/ruptures-headless/) but I'd be happy to not maintain a fork :)