### PR TITLE
Weird behaviour correction when median(K) = 0

### DIFF
--- a/ruptures/costs/costrbf.py
+++ b/ruptures/costs/costrbf.py
@@ -109,7 +109,7 @@ class CostRbf(BaseCost):
             K = pdist(signal, metric="sqeuclidean")
         K_median = np.median(K) 
         if K_median != 0:
-             k/= K_median
+             K/= K_median
         np.clip(K, 1e-2, 1e2, K)
         self.gram = np.exp(squareform(-K))
         return self

--- a/ruptures/costs/costrbf.py
+++ b/ruptures/costs/costrbf.py
@@ -107,7 +107,9 @@ class CostRbf(BaseCost):
             K = pdist(signal.reshape(-1, 1), metric="sqeuclidean")
         else:
             K = pdist(signal, metric="sqeuclidean")
-        K /= np.median(K)
+        K_median = np.median(K) 
+        if K_median != 0:
+             k/= K_median
         np.clip(K, 1e-2, 1e2, K)
         self.gram = np.exp(squareform(-K))
         return self


### PR DESCRIPTION
During some different tests, we experiment a weird behaviour with PELT (RBF cost function) 
When median(K) is equal to 0, the  segmentation is clearly weird : each segment have an equal length (5).

To experiment this you can run the following code 
```python
import ruptures
import numpy as np
curve= [0, 528, 503, 0, 0, 0, 541, 542, 0, 542, 0, 0, 0, 542, 
             500, 530, 0, 0, 515, 0, 536, 0, 0, 539, 518, 0, 0, 530, 0, 0, 
             503, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
             0, 0, 0]
curve = np.array(curve)
algo = ruptures.Pelt(model='rbf', min_size=1).fit(curve)
seg = algo.predict(pen=1)
ruptures.display(curve, seg)
```
Which leads to this segmentation : 
![rupture_error_segmentation](https://user-images.githubusercontent.com/56997675/67561735-aec88580-f71d-11e9-9980-6ceee9a15c10.png)

We basically corrected this error by not dividing if the median is 0.
We are not sure about what this correction implies mathematically speaking but with such correction we obtain this result which seems clearly better :
![rupture_seg](https://user-images.githubusercontent.com/56997675/67562410-ef74ce80-f71e-11e9-81f3-34766802ae12.png)
