### PR TITLE
Speed up BottomUp algorithm

### DIFF
--- a/ruptures/utils/bnode.py
+++ b/ruptures/utils/bnode.py
@@ -1,6 +1,8 @@
 """Binary node."""
+import functools
 
 
+@functools.total_ordering
 class Bnode:
 
     """Binary node.
@@ -25,3 +27,12 @@ class Bnode:
         elif abs(self.val) < 1e-8:
             return 0
         return self.val - (self.left.val + self.right.val)
+
+    def __lt__(self, other):
+        return self.start < other.start
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.start == other.start and self.end == other.end
+
+    def __hash__(self):
+        return hash((self.__class__, self.start, self.end))


### PR DESCRIPTION
* Maintain merge candidates in a heap/priority queue
* Use binary search to maintain a sorted list of leaves instead of rebuilding it each iteration

For a large input array, I found this to be about 5-6x faster than the current implementation for the `predict` step.  

It is somewhat more complicated, and could be implemented in a cleaner manner (e.g., create an actual priority queue class, or use some of the ideas presented in the [heapq documentation](https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes)). 

Both of these ideas would be a bit of work (that I don't have time for right now), and, depending on the choices made, could limit compatible versions of python (e.g., if data classes were used).

But I would be happy if @deepcharles or someone else used this PR as inspiration and reimplemented it in a cleaner way.