### PR TITLE
ci: add gh actions for PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,71 @@
+# Config file for the labeler Github Action
+# https://hub.docker.com/r/jimschubert/labeler-action
+# labeler "full" schema
+
+# enable labeler on issues, prs, or both.
+enable:
+  issues: true
+  prs: true
+
+# comments object allows you to specify a different message for issues and prs
+
+# comments:
+#   issues: |
+#     Thanks for opening this issue!
+#     I have applied any labels matching special text in your title and description.
+
+#     Please review the labels and make any necessary changes.
+#   prs: |
+#     Thanks for the contribution!
+#     I have applied any labels matching special text in your title and description.
+
+#     Please review the labels and make any necessary changes.
+
+# Labels is an object where:
+# - keys are labels
+# - values are objects of { include: [ pattern ], exclude: [ pattern ] }
+#    - pattern must be a valid regex, and is applied globally to
+#      title + description of issues and/or prs (see enabled config above)
+#    - 'include' patterns will associate a label if any of these patterns match
+#    - 'exclude' patterns will ignore this label if any of these patterns match
+labels:
+  'Type: Fix':
+    include:
+      - '^(bug|fix)(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Feature':
+    include:
+      - '^feat(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Build':
+    include:
+      - '^build(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Documentation':
+    include:
+      - '^docs(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Refactoring':
+    include:
+      - '^(refactor|style)(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Testing':
+    include:
+      - '^test(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Maintenance':
+    include:
+      - '^(chore|mnt)(\(.*\))?:(.*)'
+    exclude: []
+  'Type: CI':
+    include:
+      - '^ci(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Performance':
+    include:
+      - '^perf(\(.*\))?:(.*)'
+    exclude: []
+  'Type: Revert':
+    include:
+      - '^revert(\(.*\))?:(.*)'
+    exclude: []

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'Type: Feature'
+      - 'Type: Performance'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'Type: Fix'
+  - title: '📚 Documentation'
+    label: 'Type: Documentation'
+  - title: '🧰 Maintenance'
+    label:
+      - 'Type: Maintenance'
+      - 'Type: Build'
+      - 'Type: Refactoring'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,38 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Optionally, you can provide options for further constraints.
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            build
+            docs
+            style
+            refactor
+            chore
+            ci
+            perf
+            revert
+            test
+          # Configure which scopes are allowed.
+          # scopes: |
+            # core
+            # ui
+          # Configure that a scope must always be provided.
+          # requireScope: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,18 @@
+name: Label PRs and issues
+on:
+  issues:
+    types: [opened, edited, milestoned]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+
+  labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check Labels
+      id: labeler
+      uses: jimschubert/labeler-action@v2
+      with:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Three github actions are added:

- `lint-pr.yml`: verify that a pr follows the conventional commit conventions (https://github.com/amannn/action-semantic-pull-request).
- `pr-labeler.yml`: add label to PR by reading its title (https://github.com/jimschubert/labeler-action)
- `release-drafter.yml`: build a release draft for each new PR that is merged with the `main` branch (https://github.com/release-drafter/release-drafter)