### PR TITLE
ci: use joerick/cibuildwheel@v1.9.0 action in upload to pypi

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -66,18 +66,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.8'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel
       - name: Build wheels
+        uses: joerick/cibuildwheel@v1.9.0
         env:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
-        run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CIBW_BUILD_VERBOSITY: 1
+  SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.overrideVersion }}
 
 jobs:
   make_sdist:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -14,9 +14,7 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - name: Setup Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -64,8 +64,7 @@ jobs:
             python: 39
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 0
+
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0
         env:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -7,7 +7,6 @@ on:
         description: Manually force a version
 
 env:
-  SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.overrideVersion }}
   CIBW_BUILD_VERBOSITY: 1
 
 jobs:
@@ -69,6 +68,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.9.0
         env:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+          # Manually force a version
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -69,6 +69,7 @@ jobs:
         uses: joerick/cibuildwheel@v1.9.0
         env:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+          CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
       - uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -63,7 +63,7 @@ jobs:
           - os: windows-latest
             python: 39
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           fetch-depth: 0
       - name: Build wheels


### PR DESCRIPTION
Use `joerick/cibuildwheel@v1.9.0` in gh action that uploads to pypi.

Maybe this will solve the problem of the `SETUPTOOLS_SCM_PRETEND_VERSION` variable not seen on `manylinux1` (by default cibuildwheel uses `manylinux2010`.