### PR TITLE
ci: add depency for librosa

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -4,13 +4,16 @@ on:
 
 jobs:
   docs:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+    - name: Install sndfile library
+      run: |
+        apt-get install libsndfile1-dev
     - name: Install ruptures and dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: '3.8'
     - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
-        apt-get install libsndfile1-dev
+        sudo apt-get install libsndfile1-dev
     - name: Install ruptures and dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install sndfile library
+    - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
         apt-get install libsndfile1-dev
     - name: Install ruptures and dependencies

--- a/.github/workflows/publish-doc-to-remote.yml
+++ b/.github/workflows/publish-doc-to-remote.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: '3.8'
     - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
-        apt-get install libsndfile1-dev
+        sudo apt-get install libsndfile1-dev
     - name: Install ruptures and dependecies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish-doc-to-remote.yml
+++ b/.github/workflows/publish-doc-to-remote.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install sndfile library
+    - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
         apt-get install libsndfile1-dev
     - name: Install ruptures and dependecies

--- a/.github/workflows/publish-doc-to-remote.yml
+++ b/.github/workflows/publish-doc-to-remote.yml
@@ -8,13 +8,16 @@ on:
 
 jobs:
   docs:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+    - name: Install sndfile library
+      run: |
+        apt-get install libsndfile1-dev
     - name: Install ruptures and dependecies
       run: |
         python -m pip install --upgrade pip

--- a/docs/examples/music-segmentation.ipynb
+++ b/docs/examples/music-segmentation.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Music segmentation can be seen as a change point detection task and therefore can be carried out with `ruptures`.\n",
     "Roughly, it consists in finding the temporal boundaries of meaningful sections, e.g. the intro, verse, chorus and outro in a song.\n",
-    "This is an important task in the filed of music information retrieval.\n",
+    "This is an important task in the field of music information retrieval.\n",
     "\n",
     "The adopted approach is summarized as follows:\n",
     "\n",


### PR DESCRIPTION
A notebook example needs librosa and librosa needs a library that cannot be installed with `pip` (see [here](https://pysoundfile.readthedocs.io/en/latest/#installation)).

We add the dependency to the gh actions that generate the docs.