### PR TITLE
chore: set manually a working version of pip for install

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ruptures
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==21.0.1
         python -m pip install .[test]
     - name: Test with pytest
       run: |


### PR DESCRIPTION
We recently have a problem to run the test within the CI with GH Actions. 
See stackoverflow question for more detail : https://stackoverflow.com/questions/67296563/github-actions-stays-stuck-on-a-task-and-finally-fail-on-timeout

Following the [comment](https://stackoverflow.com/questions/67296563/github-actions-stays-stuck-on-a-task-and-finally-fail-on-timeout?noredirect=1#comment118990125_67296563) on the stackoverflow issue, I tried in [run-test.yml](https://github.com/deepcharles/ruptures/blob/master/.github/workflows/run-test.yml) not to upgrade `pip`. It did partially the job since more runs completed. But at the end, it stayed stuck. See [here](https://github.com/deepcharles/ruptures/actions/runs/798695169) to see the run. 

I investigated the following message in the CI : 
```
WARNING: Value for scheme.headers does not match. Please report this to <https://github.com/pypa/pip/issues/9617>
```
But it is said in the related issue that :
```
First off, this specific class of warnings can be safely ignored. They were added to help pip's maintainers identify incorrectly patched/configured Python distributions provided by redistributors (eg: with your OS, or as part of $corp's VM/Docker images etc).
```

Also in the CI trace, there is the following message : 
```
Processing /home/runner/work/ruptures/ruptures
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
```
Related also the the use of `--use-feature=in-tree-build` I found [this](https://github.com/pypa/pip/issues/2195) issue on pip. This very last issue has a [comment](https://github.com/pypa/pip/issues/2195#issuecomment-783632724) that propose to do 
```
python setup.py bdist_wheel
pip install dist/*.whl
```
instead of `pip install .` which is not a good solution for us since we are making use of the possibility to specify a `[options.extras_require]` like for instance `python -m pip install .[test]`. 

I also tried locally to upgrade pip to the latest version (`21.1`) and run `python -m pip install .[test]`. I had the similar problem as in the CI : the install process got stuck !! Local python version : `3.6.8`.

So what I did :

* In the last working run in the CI, I looked at the `pip` version. It was `21.0.1`. See [here](https://github.com/deepcharles/ruptures/runs/2409978701?check_suite_focus=true)
* Enforce the installation of this specific version of pip

It worked locally with my `3.6.8` python version. 