### PR TITLE
feat(display): more display options

### DIFF
--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -88,8 +88,12 @@ def display(
         color = (
             computed_chg_pts_color  # color of the lines indicating the computed_chg_pts
         )
-        linewidth = computed_chg_pts_linewidth  # linewidth of the lines indicating the computed_chg_pts
-        linestyle = computed_chg_pts_linestyle  # linestyle of the lines indicating the computed_chg_pts
+        linewidth = (
+            computed_chg_pts_linewidth  # linewidth of the lines indicating the computed_chg_pts
+        )
+        linestyle = (
+            computed_chg_pts_linestyle  # linestyle of the lines indicating the computed_chg_pts
+        )
         # vertical lines to mark the computed_chg_pts
         if computed_chg_pts is not None:
             for bkp in computed_chg_pts:

--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -85,19 +85,14 @@ def display(
 
         for (start, end), col in zip(pairwise(bkps), color_cycle):
             axe.axvspan(max(0, start - 0.5), end - 0.5, facecolor=col, alpha=alpha)
-        color = (
-            computed_chg_pts_color  # color of the lines indicating the computed_chg_pts
-        )
-        linewidth = computed_chg_pts_linewidth  # linewidth of the lines indicating the computed_chg_pts
-        linestyle = computed_chg_pts_linestyle  # linestyle of the lines indicating the computed_chg_pts
         # vertical lines to mark the computed_chg_pts
         if computed_chg_pts is not None:
             for bkp in computed_chg_pts:
                 if bkp != 0 and bkp < n_samples:
                     axe.axvline(
                         x=bkp - 0.5,
-                        color=color,
-                        linewidth=linewidth,
+                        color=computed_chg_pts_color,
+                        linewidth=computed_chg_pts_linewidth,
                         linestyle=linestyle,
                         alpha=computed_chg_pts_alpha,
                     )

--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -28,10 +28,14 @@ def display(
         signal (array): signal array, shape (n_samples,) or (n_samples, n_features).
         true_chg_pts (list): list of change point indexes.
         computed_chg_pts (list, optional): list of change point indexes.
-        computed_chg_pts_color (str, optional): color.
-        computed_chg_pts_linewidth (int, optional): linewidth for computed_chg_pts.
-        computed_chg_pts_linestyle (str, optional): linestyle for computed_chg_pts.
-        computed_chg_pts_alpha (list, optional): alpha for computed_chg_pts_linestyle.
+        computed_chg_pts_color (str, optional): color of the lines indicating
+            the computed_chg_pts. Defaults to "k".
+        computed_chg_pts_linewidth (int, optional): linewidth of the lines
+            indicating the computed_chg_pts. Defaults to 3.
+        computed_chg_pts_linestyle (str, optional): linestyle of the lines
+            indicating the computed_chg_pts. Defaults to "--".
+        computed_chg_pts_alpha (float, optional): alpha of the lines indicating
+            the computed_chg_pts. Defaults to "1.0".
         **kwargs : all additional keyword arguments are passed to the plt.subplots call.
 
     Returns:
@@ -76,9 +80,9 @@ def display(
         for (start, end), col in zip(pairwise(bkps), color_cycle):
             axe.axvspan(max(0, start - 0.5), end - 0.5, facecolor=col, alpha=alpha)
 
-        color = computed_chg_pts_color  # color of the lines indicating the computed_chg_pts
-        linewidth = computed_chg_pts_linewidth  # linewidth of the lines indicating the computed_chg_pts
-        linestyle = computed_chg_pts_linestyle  # linestyle of the lines indicating the computed_chg_pts
+        color = computed_chg_pts_color
+        linewidth = computed_chg_pts_linewidth
+        linestyle = computed_chg_pts_linestyle
         # vertical lines to mark the computed_chg_pts
         if computed_chg_pts is not None:
             for bkp in computed_chg_pts:

--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -93,7 +93,7 @@ def display(
                         x=bkp - 0.5,
                         color=computed_chg_pts_color,
                         linewidth=computed_chg_pts_linewidth,
-                        linestyle=linestyle,
+                        linestyle=computed_chg_pts_linestyle,
                         alpha=computed_chg_pts_alpha,
                     )
 

--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -13,7 +13,10 @@ class MatplotlibMissingError(RuntimeError):
     pass
 
 
-def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
+def display(
+    signal, true_chg_pts, computed_chg_pts=None, computed_chg_pts_color="k",
+        computed_chg_pts_linewidth=3, computed_chg_pts_linestyle="--",
+        computed_chg_pts_alpha=1.0, **kwargs):
     """Display a signal and the change points provided in alternating colors.
     If another set of change point is provided, they are displayed with dashed
     vertical dashed lines. The following matplotlib subplots options is set by
@@ -25,6 +28,10 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
         signal (array): signal array, shape (n_samples,) or (n_samples, n_features).
         true_chg_pts (list): list of change point indexes.
         computed_chg_pts (list, optional): list of change point indexes.
+        computed_chg_pts_color (str, optional): color.
+        computed_chg_pts_linewidth (int, optional): linewidth for computed_chg_pts.
+        computed_chg_pts_linestyle (str, optional): linestyle for computed_chg_pts.
+        computed_chg_pts_alpha (list, optional): alpha for computed_chg_pts_linestyle.
         **kwargs : all additional keyword arguments are passed to the plt.subplots call.
 
     Returns:
@@ -69,9 +76,9 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
         for (start, end), col in zip(pairwise(bkps), color_cycle):
             axe.axvspan(max(0, start - 0.5), end - 0.5, facecolor=col, alpha=alpha)
 
-        color = "k"  # color of the lines indicating the computed_chg_pts
-        linewidth = 3  # linewidth of the lines indicating the computed_chg_pts
-        linestyle = "--"  # linestyle of the lines indicating the computed_chg_pts
+        color = computed_chg_pts_color  # color of the lines indicating the computed_chg_pts
+        linewidth = computed_chg_pts_linewidth  # linewidth of the lines indicating the computed_chg_pts
+        linestyle = computed_chg_pts_linestyle  # linestyle of the lines indicating the computed_chg_pts
         # vertical lines to mark the computed_chg_pts
         if computed_chg_pts is not None:
             for bkp in computed_chg_pts:
@@ -81,6 +88,7 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
                         color=color,
                         linewidth=linewidth,
                         linestyle=linestyle,
+                        alpha=computed_chg_pts_alpha,
                     )
 
     fig.tight_layout()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -53,3 +53,24 @@ def test_display_with_new_options(signal_bkps):
         fig, axarr = display(signal[:, 0], bkps, facecolor="k", edgecolor="b")
     except MatplotlibMissingError:
         pytest.skip("matplotlib is not installed")
+
+
+def test_display_with_computed_chg_pts_options(signal_bkps):
+    try:
+        signal, bkps = signal_bkps
+        fig, axarr = display(signal, bkps)
+        fig, axarr = display(signal, bkps, bkps)
+
+        fig, axarr = display(signal, bkps, bkps, computed_chg_pts_color="k")
+        fig, axarr = display(
+            signal, bkps, bkps, computed_chg_pts_color="k",
+            computed_chg_pts_linewidth=3)
+        fig, axarr = display(
+            signal, bkps, bkps, computed_chg_pts_color="k",
+            computed_chg_pts_linewidth=3, computed_chg_pts_linestyle="--")
+        fig, axarr = display(
+            signal, bkps, bkps, computed_chg_pts_color="k",
+            computed_chg_pts_linewidth=3, computed_chg_pts_linestyle="--",
+            computed_chg_pts_alpha=1.0)
+    except MatplotlibMissingError:
+        pytest.skip("matplotlib is not installed")


### PR DESCRIPTION
Firstly thanks for a cool library.  The following proposed change is cosmetic only.

The current `display` plot of the `computed_chg_pts` renders the dashed vertical dashed lines with `linewidth=3` and no alpha.  This results in the dashed vertical lines overlaying the signal and obscuring it.


```
rpt.display(signal, results, computed_chg_pts, figsize=(8, 4))
```
![image](https://user-images.githubusercontent.com/96679/119225697-36929380-bafd-11eb-9cd3-720669f2115c.png)
**Please note**  these example plots are **not broken**, they are using a modified `results` list with only results from a specific window plotted, they are just highlighting a specific change point in a defined period, hence no leading change points or trailing change points are plotted.

The proposed change allows the user to pass additional arguments that allow the user to format the `computed_chg_pts` axvline parameters to overcome this resulting in a clearer visualisation of the change point and the signal.

```
rpt.display(
    signal, results, computed_chg_pts, computed_chg_pts_linewidth=1,
    computed_chg_pts_alpha=0.3, figsize=(8, 4))
```
![image](https://user-images.githubusercontent.com/96679/119225942-98073200-bafe-11eb-959e-8192283ba73c.png)

The change maintains the current format as the default behaviour and is therefore backwards compatible.
