### PR TITLE
chore: better PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,3 +69,7 @@ labels:
     include:
       - '^revert(\(.*\))?:(.*)'
     exclude: []
+  'skip-changelog':
+    include:
+      - '^(chore: pre-commit autoupdate)'
+    exclude: []

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,12 +53,13 @@ docs =
     jupyter
     librosa
     matplotlib
-    mkdocs
+    mkdocs==1.1.2
     mkdocs-macros-plugin
     mkdocs-material
     mkdocstrings
     mknotebooks
     pymdown-extensions
+    nltk
 
 [build_ext]
 inplace=1

--- a/src/ruptures/show/display.py
+++ b/src/ruptures/show/display.py
@@ -13,7 +13,16 @@ class MatplotlibMissingError(RuntimeError):
     pass
 
 
-def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
+def display(
+    signal,
+    true_chg_pts,
+    computed_chg_pts=None,
+    computed_chg_pts_color="k",
+    computed_chg_pts_linewidth=3,
+    computed_chg_pts_linestyle="--",
+    computed_chg_pts_alpha=1.0,
+    **kwargs
+):
     """Display a signal and the change points provided in alternating colors.
     If another set of change point is provided, they are displayed with dashed
     vertical dashed lines. The following matplotlib subplots options is set by
@@ -25,6 +34,14 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
         signal (array): signal array, shape (n_samples,) or (n_samples, n_features).
         true_chg_pts (list): list of change point indexes.
         computed_chg_pts (list, optional): list of change point indexes.
+        computed_chg_pts_color (str, optional): color of the lines indicating
+            the computed_chg_pts. Defaults to "k".
+        computed_chg_pts_linewidth (int, optional): linewidth of the lines
+            indicating the computed_chg_pts. Defaults to 3.
+        computed_chg_pts_linestyle (str, optional): linestyle of the lines
+            indicating the computed_chg_pts. Defaults to "--".
+        computed_chg_pts_alpha (float, optional): alpha of the lines indicating
+            the computed_chg_pts. Defaults to "1.0".
         **kwargs : all additional keyword arguments are passed to the plt.subplots call.
 
     Returns:
@@ -68,19 +85,16 @@ def display(signal, true_chg_pts, computed_chg_pts=None, **kwargs):
 
         for (start, end), col in zip(pairwise(bkps), color_cycle):
             axe.axvspan(max(0, start - 0.5), end - 0.5, facecolor=col, alpha=alpha)
-
-        color = "k"  # color of the lines indicating the computed_chg_pts
-        linewidth = 3  # linewidth of the lines indicating the computed_chg_pts
-        linestyle = "--"  # linestyle of the lines indicating the computed_chg_pts
         # vertical lines to mark the computed_chg_pts
         if computed_chg_pts is not None:
             for bkp in computed_chg_pts:
                 if bkp != 0 and bkp < n_samples:
                     axe.axvline(
                         x=bkp - 0.5,
-                        color=color,
-                        linewidth=linewidth,
-                        linestyle=linestyle,
+                        color=computed_chg_pts_color,
+                        linewidth=computed_chg_pts_linewidth,
+                        linestyle=computed_chg_pts_linestyle,
+                        alpha=computed_chg_pts_alpha,
                     )
 
     fig.tight_layout()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -53,3 +53,34 @@ def test_display_with_new_options(signal_bkps):
         fig, axarr = display(signal[:, 0], bkps, facecolor="k", edgecolor="b")
     except MatplotlibMissingError:
         pytest.skip("matplotlib is not installed")
+
+
+def test_display_with_computed_chg_pts_options(signal_bkps):
+    try:
+        signal, bkps = signal_bkps
+        fig, axarr = display(signal, bkps)
+        fig, axarr = display(signal, bkps, bkps)
+
+        fig, axarr = display(signal, bkps, bkps, computed_chg_pts_color="k")
+        fig, axarr = display(
+            signal, bkps, bkps, computed_chg_pts_color="k", computed_chg_pts_linewidth=3
+        )
+        fig, axarr = display(
+            signal,
+            bkps,
+            bkps,
+            computed_chg_pts_color="k",
+            computed_chg_pts_linewidth=3,
+            computed_chg_pts_linestyle="--",
+        )
+        fig, axarr = display(
+            signal,
+            bkps,
+            bkps,
+            computed_chg_pts_color="k",
+            computed_chg_pts_linewidth=3,
+            computed_chg_pts_linestyle="--",
+            computed_chg_pts_alpha=1.0,
+        )
+    except MatplotlibMissingError:
+        pytest.skip("matplotlib is not installed")


### PR DESCRIPTION
thanks to this PR, PRs initiated by pre-commit autoupdate will not be part of the changelog (tagged as "skip-changelog")