### PR TITLE
fix: lru-cache usage

### DIFF
--- a/src/ruptures/detection/binseg.py
+++ b/src/ruptures/detection/binseg.py
@@ -33,8 +33,6 @@ class Binseg(BaseEstimator):
         self.jump = jump
         self.n_samples = None
         self.signal = None
-        # cache for intermediate results
-        self.single_bkp = lru_cache(maxsize=None)(self._single_bkp)
 
     def _seg(self, n_bkps=None, pen=None, epsilon=None):
         """Computes the binary segmentation.
@@ -83,7 +81,8 @@ class Binseg(BaseEstimator):
         }
         return partition
 
-    def _single_bkp(self, start, end):
+    @lru_cache(maxsize=None)
+    def single_bkp(self, start, end):
         """Return the optimal breakpoint of [start:end] (if it exists)."""
         segment_cost = self.cost.error(start, end)
         if np.isinf(segment_cost) and segment_cost < 0:  # if constant on segment

--- a/src/ruptures/detection/bottomup.py
+++ b/src/ruptures/detection/bottomup.py
@@ -35,7 +35,6 @@ class BottomUp(BaseEstimator):
         self.n_samples = None
         self.signal = None
         self.leaves = None
-        self.merge = lru_cache(maxsize=None)(self._merge)
 
     def _grow_tree(self):
         """Grow the entire binary tree."""
@@ -66,7 +65,8 @@ class BottomUp(BaseEstimator):
             leaves.append(leaf)
         return leaves
 
-    def _merge(self, left, right):
+    @lru_cache(maxsize=None)
+    def merge(self, left, right):
         """Merge two contiguous segments."""
         assert left.end == right.start, "Segments are not contiguous."
         start, end = left.start, right.end

--- a/src/ruptures/detection/dynp.py
+++ b/src/ruptures/detection/dynp.py
@@ -25,7 +25,6 @@ class Dynp(BaseEstimator):
             jump (int, optional): subsample (one every *jump* points).
             params (dict, optional): a dictionary of parameters for the cost instance.
         """
-        self.seg = lru_cache(maxsize=None)(self._seg)  # dynamic programming
         if custom_cost is not None and isinstance(custom_cost, BaseCost):
             self.cost = custom_cost
         else:
@@ -38,7 +37,8 @@ class Dynp(BaseEstimator):
         self.jump = jump
         self.n_samples = None
 
-    def _seg(self, start, end, n_bkps):
+    @lru_cache(maxsize=None)
+    def seg(self, start, end, n_bkps):
         """Recurrence to find the optimal partition of signal[start:end].
 
         This method is to be memoized and then used.

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from itertools import product
 
 import numpy as np
@@ -334,3 +335,9 @@ def test_model_small_signal_bis(signal_bkps_5D_n10, algo, model):
     signal, _ = signal_bkps_5D_n10
     with pytest.raises(BadSegmentationParameters):
         algo(model=model, min_size=5, jump=2).fit_predict(signal, 2)
+
+
+def test_binseg_deepcopy():
+    binseg = Binseg()
+    binseg_copy = deepcopy(binseg)
+    assert id(binseg.single_bkp) != id(binseg_copy.single_bkp)


### PR DESCRIPTION
Hi!

I tried to use `copy.deepcopy` to copy `Binseg` object and met a problem: `binseg.single_bkp` and `deepcopy(binseg).single_bkp` referred to the same object. So, I can not use `binseg_copy.single_bkp` because it tries to use the data from the original object.

It seems to be caused by the way `lru_cache` is used. Are there any reasons not to use it with `@` decorator syntax?