### PR TITLE
ci: do not triggers some gh actions for PR labelled as skip-changelog

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,9 +1,12 @@
 name: "Check docs"
 on:
-- pull_request
+  pull_request:
+    branches: [ master ]
+    types: [labeled]
 
 jobs:
   docs:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -2,7 +2,6 @@ name: "Check docs"
 on:
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   docs:

--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -10,9 +10,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [labeled]
 
 jobs:
   coverage:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -10,7 +10,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   coverage:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,7 +8,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   build:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,9 +8,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [labeled]
 
 jobs:
   build:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
As of today, for the PR labelled as `skip-changelog` we run the same tests in the CI that any other PRs. Since as of today it is only linked to pre-commit autoupdate tasks, we do not need to run all the checks. 

Adds a conditions to the following GH Actions so that it does not run some checks for PR labelled `skip-changelog` :

- [x] .github/workflows/check-docs.yml
- [x] .github/workflows/run-test-coverage.yml
- [x] .github/workflows/run-test.yml
