### PR TITLE
ci: do not triggers some gh actions for pre-commit-ci-update-config branch

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,9 +1,12 @@
 name: "Check docs"
 on:
-- pull_request
+  pull_request:
+    branches: [ master ]
+    types: [labeled]
 
 jobs:
   docs:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -2,10 +2,11 @@ name: "Check docs"
 on:
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.pre-commit-config.yaml'
 
 jobs:
   docs:
-    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -2,7 +2,6 @@ name: "Check docs"
 on:
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   docs:

--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -10,9 +10,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [labeled]
 
 jobs:
   coverage:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -10,7 +10,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   coverage:

--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -10,10 +10,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.pre-commit-config.yaml'
 
 jobs:
   coverage:
-    if: ${{ github.event.label.name != 'skip-changelog' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    # if: ${{ !startsWith(github.event.pull_request.name, 'chore: pre-commit') }}
+    if: ${{ !contains(github.event.pull_request.title, 'pre-commit autoupdate') }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -21,11 +21,11 @@ jobs:
             python-version: 3.9
     runs-on: ${{ matrix.os }}
     steps:
-    - name: To be deleted - print pr name
-      env:
-        GH_EVENT_CONTEXT_PR = ${{ toJson(github.event.pull_request) }}
-      run: |
-        echo "$GH_EVENT_CONTEXT_PR"
+    # - name: To be deleted - print pr name
+    #   env:
+    #     GH_EVENT_CONTEXT_PR = ${{ toJson(github.event.pull_request) }}
+    #   run: |
+    #     echo "$GH_EVENT_CONTEXT_PR"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: To be deleted - print pr name
-      run: echo "${{github.event.pull_request}}"
+      run: |
+        array = ${{github.event.pull_request}}
+        echo "${array[*]}"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,7 +8,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled]
 
 jobs:
   build:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: To be deleted - print pr name
-      run: echo github.event.pull_request.name
+      run: echo ${{github.event.pull_request.name}}
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.label.name != 'skip-changelog' }}
+    # if: ${{ !startsWith(github.event.pull_request.name, 'chore: pre-commit') }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -21,6 +21,8 @@ jobs:
             python-version: 3.9
     runs-on: ${{ matrix.os }}
     steps:
+    - name: To be deleted - print pr name
+      run: echo github.event.pull_request.name
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,9 +22,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: To be deleted - print pr name
+      env:
+        GH_EVENT_CONTEXT_PR = ${{ toJson(github.event.pull_request) }}
       run: |
-        array = ${{github.event.pull_request}}
-        echo "${array[*]}"
+        echo "$GH_EVENT_CONTEXT_PR"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,10 +8,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.pre-commit-config.yaml'
 
 jobs:
   build:
-    if: ${{ !contains(github.event.pull_request.title, 'pre-commit autoupdate') }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -21,11 +22,6 @@ jobs:
             python-version: 3.9
     runs-on: ${{ matrix.os }}
     steps:
-    # - name: To be deleted - print pr name
-    #   env:
-    #     GH_EVENT_CONTEXT_PR = ${{ toJson(github.event.pull_request) }}
-    #   run: |
-    #     echo "$GH_EVENT_CONTEXT_PR"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: To be deleted - print pr name
-      run: echo ${{github.event.pull_request.name}}
+      run: echo "${{github.event.pull_request.name}}"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: To be deleted - print pr name
-      run: echo "${{github.event.pull_request.name}}"
+      run: echo "${{github.event.pull_request}}"
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -8,9 +8,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [labeled]
 
 jobs:
   build:
+    if: ${{ github.event.label.name != 'skip-changelog' }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]


### PR DESCRIPTION
The situation : 

As of today, for the PRs automatically generated by `pre-commit-ci` from branch `pre-commit-ci-update-config` to `master` and only affecting `.pre-commit-config.yaml`, run all the CI tests like any other PRs. 

What we do :

When only `.pre-commit-config.yaml` is affected by the PR, then the following Gh Actions are not run : 

- [x]  .github/workflows/check-docs.yml
- [x]  .github/workflows/run-test-coverage.yml
- [x]  .github/workflows/run-test.yml