### PR TITLE
style: add module imported but unused in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 max-line-length = 127
 max-complexity = 10
 select = E9,F63,F7,F82,F401
+per-file-ignores = __init__.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 127
 max-complexity = 10
-select = E9,F63,F7,F82
+select = E9,F63,F7,F82,F401

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 
 ext_modules = [
     Extension(

--- a/src/ruptures/datasets/pw_linear.py
+++ b/src/ruptures/datasets/pw_linear.py
@@ -3,7 +3,6 @@ import numpy as np
 from numpy.random import normal
 
 from . import pw_constant
-from ruptures.utils import draw_bkps
 
 
 def pw_linear(n_samples=200, n_features=1, n_bkps=3, noise_std=None):

--- a/src/ruptures/detection/kernelcpd.py
+++ b/src/ruptures/detection/kernelcpd.py
@@ -1,6 +1,6 @@
 r"""Efficient kernel change point detection (dynamic programming)"""
 
-from ruptures.base import BaseCost, BaseEstimator
+from ruptures.base import BaseEstimator
 from ruptures.costs import cost_factory
 from ruptures.utils import from_path_matrix_to_bkps_list, sanity_check
 from ruptures.exceptions import BadSegmentationParameters

--- a/src/ruptures/metrics/hamming.py
+++ b/src/ruptures/metrics/hamming.py
@@ -1,7 +1,7 @@
 """Hamming metric for segmentation."""
 
 import numpy as np
-from scipy.sparse import block_diag, triu
+from scipy.sparse import triu
 
 from ruptures.metrics.sanity_check import sanity_check
 from ruptures.utils import pairwise

--- a/src/ruptures/metrics/precisionrecall.py
+++ b/src/ruptures/metrics/precisionrecall.py
@@ -1,10 +1,7 @@
 r"""Precision and recall"""
-from itertools import groupby, product
-
-import numpy as np
+from itertools import product
 
 from ruptures.metrics.sanity_check import sanity_check
-from ruptures.utils import unzip
 
 
 def precision_recall(true_bkps, my_bkps, margin=10):

--- a/src/ruptures/utils/__init__.py
+++ b/src/ruptures/utils/__init__.py
@@ -3,4 +3,4 @@ from ruptures.utils._utils.convert_path_matrix import from_path_matrix_to_bkps_l
 
 from .bnode import Bnode
 from .drawbkps import draw_bkps
-from .utils import admissible_filter, pairwise, sanity_check, unzip
+from .utils import pairwise, sanity_check, unzip

--- a/src/ruptures/utils/utils.py
+++ b/src/ruptures/utils/utils.py
@@ -2,9 +2,6 @@
 
 from itertools import tee
 from math import ceil
-from random import choice
-
-import numpy as np
 
 
 def pairwise(iterable):

--- a/src/ruptures/utils/utils.py
+++ b/src/ruptures/utils/utils.py
@@ -16,16 +16,6 @@ def unzip(seq):
     return zip(*seq)
 
 
-def admissible_filter(start, end, jump, min_size):
-    """A filter to know if an index can be considered as a change point."""
-
-    def filtre(ind):
-        """Return True if index is admissible."""
-        return all((ind - start > min_size, end - ind > min_size, ind % jump == 0))
-
-    return filtre
-
-
 def sanity_check(n_samples, n_bkps, jump, min_size):
     """Check if a partition if possible given some segmentation parameters.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,5 @@
 from itertools import product
 
-import numpy as np
 import pytest
 
 from ruptures.datasets import pw_constant, pw_linear, pw_normal, pw_wavy

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from ruptures.metrics import hausdorff, meantime, precision_recall, randindex


### PR DESCRIPTION
Just add the F401 flake8 code to `.flake8` so that we have a warning message when there is an unused import. 
For instance in `src/ruptures/utils/utils.py` [here](https://github.com/deepcharles/ruptures/blob/d211c5c6257722aefafa81499a3171f1bf42a6a7/src/ruptures/utils/utils.py#L7) with `numpy`.
