### PR TITLE
test: remove coverage computation from test

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -31,4 +31,4 @@ jobs:
         python -m pip install .[test]
     - name: Test with pytest
       run: |
-        python -m pytest
+        python -m pytest --no-cov


### PR DESCRIPTION
Since the coverage is computed in `.github/workflows/run-test-coverage.yml`, we do not need to compute code coverage when we run the tests with `.github/workflows/run-test.yml`.

Moreover (and this is the main reason for the current PR), adding the `--no-cov` option make the tests run **way** faster ! Since we run those tests on a matrix on `python-version` x `os`, it might be a significant improvement for the time needed in the CI to run the tests !
