### PR TITLE
ci(gh-tests): change pip version for test jobs

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ruptures
       run: |
-        python -m pip install pip==21.0.1
+        python -m pip install --upgrade pip
         python -m pip install .[test]
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Some tests do not complete and time out. 
We started noting this behaviour in https://github.com/deepcharles/ruptures/pull/198
Tests are fine for python v3.8 and v3.9. Nevertheless, for v3.6 and v3.7, jobs stay stuck on the `python -m pip install .[test]` instruction. 

Previously, a specific pip version was enforced because at that time there was also some GH Actions jobs that stayed stuck. See https://github.com/deepcharles/ruptures/pull/153

 