### PR TITLE
ci: do not run tests when only documentation is modified

### DIFF
--- a/.github/workflows/run-test-coverage.yml
+++ b/.github/workflows/run-test-coverage.yml
@@ -12,6 +12,7 @@ on:
     branches: [ master ]
     paths-ignore:
       - '.pre-commit-config.yaml'
+      - 'docs/**'
 
 jobs:
   coverage:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -10,6 +10,7 @@ on:
     branches: [ master ]
     paths-ignore:
       - '.pre-commit-config.yaml'
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
Prevent the two following GH Actions to run when only documentation is modified : 

* `ruptures/.github/workflows/run-test.yml`
* `ruptures/.github/workflows/run-test-coverage.yml`

