### PR TITLE
fix: CostMl fitting behaviour

### DIFF
--- a/src/ruptures/costs/costml.py
+++ b/src/ruptures/costs/costml.py
@@ -18,7 +18,7 @@ class CostMl(BaseCost):
         Args:
             metric (ndarray, optional): PSD matrix that defines a Mahalanobis-type pseudo distance. If None, defaults to the Mahalanobis matrix. Shape (n_features, n_features).
         """
-        self.metric = metric
+        self.has_custom_metric = False if self.metric is None else True
         self.gram = None
         self.min_size = 2
 
@@ -34,8 +34,8 @@ class CostMl(BaseCost):
 
         s_ = signal.reshape(-1, 1) if signal.ndim == 1 else signal
 
-        # Mahalanobis metric if self.metric is None
-        if self.metric is None:
+        # fit a Mahalanobis metric if self.has_custom_metric is False
+        if self.has_custom_metric is False:
             covar = np.cov(s_.T)
             self.metric = inv(covar.reshape(1, 1) if covar.size == 1 else covar)
 

--- a/src/ruptures/costs/costml.py
+++ b/src/ruptures/costs/costml.py
@@ -20,7 +20,7 @@ class CostMl(BaseCost):
                 Mahalanobis-type pseudo distance. If None, defaults to the
                 Mahalanobis matrix. Shape (n_features, n_features).
         """
-        self.metric = metric # metric matrix
+        self.metric = metric  # metric matrix
         self.has_custom_metric = False if self.metric is None else True
         self.gram = None
         self.min_size = 2

--- a/src/ruptures/costs/costml.py
+++ b/src/ruptures/costs/costml.py
@@ -16,8 +16,11 @@ class CostMl(BaseCost):
         """Create a new instance.
 
         Args:
-            metric (ndarray, optional): PSD matrix that defines a Mahalanobis-type pseudo distance. If None, defaults to the Mahalanobis matrix. Shape (n_features, n_features).
+            metric (ndarray, optional): PSD matrix that defines a
+                Mahalanobis-type pseudo distance. If None, defaults to the
+                Mahalanobis matrix. Shape (n_features, n_features).
         """
+        self.metric = metric # metric matrix
         self.has_custom_metric = False if self.metric is None else True
         self.gram = None
         self.min_size = 2
@@ -26,12 +29,12 @@ class CostMl(BaseCost):
         """Set parameters of the instance.
 
         Args:
-            signal (array): signal. Shape (n_samples,) or (n_samples, n_features)
+            signal (array): signal. Shape (n_samples,) or
+                (n_samples, n_features)
 
         Returns:
             self
         """
-
         s_ = signal.reshape(-1, 1) if signal.ndim == 1 else signal
 
         # fit a Mahalanobis metric if self.has_custom_metric is False
@@ -55,7 +58,8 @@ class CostMl(BaseCost):
             float: segment cost
 
         Raises:
-            NotEnoughPoints: when the segment is too short (less than ``'min_size'`` samples).
+            NotEnoughPoints: when the segment is too short (less than
+                ``'min_size'`` samples).
         """
         if end - start < self.min_size:
             raise NotEnoughPoints

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -178,7 +178,7 @@ def test_costml(signal_bkps_5D_noisy, signal_bkps_1D_noisy):
         c.fit(signal=signal)
         c.error(0, 100)
         c.sum_of_costs(bkps)
-    # with a user-defined metric matric
+    # with a user-defined metric matrix
     signal, bkps = signal_bkps_5D_noisy
     _, n_dims = signal.shape
     c = CostMl(metric=np.eye(n_dims))

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -168,10 +168,9 @@ def test_costnormal():
 
 def test_costml(signal_bkps_5D_noisy, signal_bkps_1D_noisy):
     """Test if `CostMl.fit` actually (re-)fits the metric matrix.
-    
-    Refitting the metric matrix should only happen if the user did not provide a
-    metric matrix.
 
+    Refitting the metric matrix should only happen if the user did not
+    provide a metric matrix.
     """
     # no user-defined metric matrix
     c = CostMl()
@@ -181,10 +180,8 @@ def test_costml(signal_bkps_5D_noisy, signal_bkps_1D_noisy):
         c.sum_of_costs(bkps)
     # with a user-defined metric matric
     signal, bkps = signal_bkps_5D_noisy
-    _, n_dims = signal.shape 
+    _, n_dims = signal.shape
     c = CostMl(metric=np.eye(n_dims))
     c.fit(signal)
     c.error(10, 50)
     assert np.allclose(c.metric, np.eye(n_dims))
-
-


### PR DESCRIPTION
When called  twice `CostMl.fit` does not recompute the `CostMl.metric` matrix. For instance the following code fails.

```python
import ruptures as rpt

c = rpt.costs.CostMl()

signal_1D, _ = rpt.pw_constant(n_features=1)
signal_5D, _ = rpt.pw_constant(n_features=5)

c.fit(signal_1D)
c.fit(signal_5D)
# >> ValueError
```
This is because the second call of `.fit()` does not recompute the metric matrix as it should. Array dimensions become incoherent. 

**Expected behaviour.** On the second call of `.fit()`, the Mahalanobis metric matrix should be recomputed and no error should be raised. However if the user provided a metric matrix, it should be used in priority and no new computation is needed.