### PR TITLE
fix: use cibuildwheel package and add tests

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -9,6 +9,9 @@ on:
 env:
   CIBW_BUILD_VERBOSITY: 1
   SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.overrideVersion }}
+  # Run the package tests using `pytest`
+  CIBW_TEST_REQUIRES: pytest
+  CIBW_TEST_COMMAND: pytest {project}/tests
 
 jobs:
   make_sdist:
@@ -53,9 +56,6 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
-          # Run the package tests using `pytest`
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {project}/tests
 
       - uses: actions/upload-artifact@v2
         with:
@@ -87,9 +87,6 @@ jobs:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
-          # Run the package tests using `pytest`
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest {project}/tests
       - uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -91,4 +91,17 @@ jobs:
         with:
           path: wheelhouse/*.whl
 
+  upload_all:
+    needs: [build_wheels, build_aarch64_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}
+
 

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
@@ -36,39 +36,27 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        bitness: [32, 64]
-        python: [36, 37, 38, 39]
-        include:
-          # Run 32 and 64 bits version in parallel for Linux and Windows
-          - os: windows-latest
-            bitness: 64
-            platform_id: win_amd64
-          - os: windows-latest
-            bitness: 32
-            platform_id: win32
-          - os: ubuntu-latest
-            bitness: 64
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
-            bitness: 32
-            platform_id: manylinux_i686
-          - os: macos-latest
-            bitness: 64
-            platform_id: macosx_x86_64
-        exclude:
-          - os: macos-latest
-            bitness: 32
-          - os: windows-latest
-            python: 39
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
-          # Manually force a version
+          # Disable explicitly python 3.10 and building PyPy wheels
+          CIBW_SKIP: cp310-* pp*
+          CIBW_PRERELEASE_PYTHONS: False
+          # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
+          # Run the package tests using `pytest`
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {project}/tests
+
       - uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl
@@ -84,31 +72,26 @@ jobs:
             arch: aarch64
             platform_id: manylinux_aarch64
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
-          # Manually force a version
+          # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
+          # Run the package tests using `pytest`
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {project}/tests
       - uses: actions/upload-artifact@v2
         with:
           path: wheelhouse/*.whl
 
-  upload_all:
-    needs: [build_wheels, build_aarch64_wheels, make_sdist]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: artifact
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.4.1
-      with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ build-backend = "setuptools.build_meta"
 # https://docs.pytest.org/en/stable/customize.html#pyproject-toml
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--cov-report=xml --cov-report=term:skip-covered --cov=ruptures"
 testpaths = ["tests"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
GHActions supposed to build and upload both the wheels and  SDist to Pypi failed (timeout after 6 hours) : https://github.com/deepcharles/ruptures/actions/runs/1291048776 failed 

* Instead of using `joerick/cibuildwheel@v1.9.0`, we now use the `cibuildwheel` package directly. It allowed us to get rid of the manual `include` and `exclude` in the matrix for the `build_wheels` job
* As a bonus, now wheels for Python v3.9 on Windows. 
* We explicitly ask not to build wheels 
    * for Python v3.10
    * for PyPy 
* We manually force a version (and avoid building local wheels, the ones with `0.1.dev1` prefix)
* We added a immediate test of the built wheels (feature offered by `cibuildwheel` via `CIBW_TEST_REQUIRES` and `CIBW_TEST_COMMAND`
* We switch from `actions/checkout@v1` to `actions/checkout@v2`
* Removed an incompatible `pytest` option in `pyproject.toml`