### PR TITLE
test: better handling of mahalanobis

### DIFF
--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -100,7 +100,17 @@ def test_costs_5D_names(signal_bkps_5D, cost_name):
 def test_costs_5D_noisy_names(signal_bkps_5D_noisy, cost_name):
     signal, bkps = signal_bkps_5D_noisy
     cost = cost_factory(cost_name)
-    cost.fit(signal)
+    try:
+        cost.fit(signal)
+    except np.linalg.LinAlgError as e:
+        if cost_name == "mahalanobis":
+            reason_msg = (
+                "The Mahalanobis metric matrix cannot be computed "
+                "because the signal has a singular covariance matrix"
+            )
+            pytest.skip(reason_msg)
+        else:
+            raise
     cost.error(0, 100)
     cost.error(100, signal.shape[0])
     cost.error(10, 50)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -83,7 +83,17 @@ def test_costs_1D_noisy_names(signal_bkps_1D_noisy, cost_name):
 def test_costs_5D_names(signal_bkps_5D, cost_name):
     signal, bkps = signal_bkps_5D
     cost = cost_factory(cost_name)
-    cost.fit(signal)
+    try:
+        cost.fit(signal)
+    except np.linalg.LinAlgError as e:
+        if cost_name == "mahalanobis":
+            reason_msg = (
+                "The Mahalanobis metric matrix cannot be computed "
+                "because the signal has a singular covariance matrix"
+            )
+            pytest.skip(reason_msg)
+        else:
+            raise
     cost.error(0, 100)
     cost.error(100, signal.shape[0])
     cost.error(10, 50)
@@ -100,17 +110,7 @@ def test_costs_5D_names(signal_bkps_5D, cost_name):
 def test_costs_5D_noisy_names(signal_bkps_5D_noisy, cost_name):
     signal, bkps = signal_bkps_5D_noisy
     cost = cost_factory(cost_name)
-    try:
-        cost.fit(signal)
-    except np.linalg.LinAlgError as e:
-        if cost_name == "mahalanobis":
-            reason_msg = (
-                "The Mahalanobis metric matrix cannot be computed "
-                "because the signal has a singular covariance matrix"
-            )
-            pytest.skip(reason_msg)
-        else:
-            raise
+    cost.fit(signal)
     cost.error(0, 100)
     cost.error(100, signal.shape[0])
     cost.error(10, 50)


### PR DESCRIPTION
From time to time, `test_costs_5D_names` fails on `CostMl` because the random signal has a singular covariance matrix. 
When this happens, the test should be skipped. This will not affect coverage since this part of the code is also tested in `test_costs_5D_noisy_names`.