### PR TITLE
fix: random behaviour of KernelCPD (Pelt)

### DIFF
--- a/src/ruptures/detection/_detection/ekcpd_pelt_computation.c
+++ b/src/ruptures/detection/_detection/ekcpd_pelt_computation.c
@@ -63,7 +63,7 @@ void ekcpd_pelt_compute(double *signal, int n_samples, int n_dims, double beta, 
             c_r += kernel_value_by_name(&(signal[s * n_dims]), &(signal[(t - 1) * n_dims]), n_dims, kernelDescObj);
             S[s] += 2 * c_r - diag_element;
         }
-        c_cost = D[t] - D[s] - S[0] / t;
+        c_cost = D[t] - D[0] - S[0] / t;
         M_V[t] = c_cost + beta;
     }
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -316,6 +316,25 @@ def test_kernelcpd_small_signal(signal_bkps_5D_n10, kernel):
     )
 
 
+@pytest.mark.parametrize("kernel", ["linear", "rbf", "cosine"])
+def test_kernelcpd_small_signal_same_result(signal_bkps_5D_n10, kernel):
+    signal, _ = signal_bkps_5D_n10
+    algo = KernelCPD(kernel=kernel)
+    list_of_segmentations = list()
+    n_iter = 100
+    for _ in range(n_iter):
+        bkps = algo.fit(signal=signal).predict(pen=1.0)
+        list_of_segmentations.append(bkps)
+
+    # test if all segmentations are equal
+    first_bkps = list_of_segmentations[0]
+    all_elements_are_equal = all(
+        first_bkps == other_bkps for other_bkps in list_of_segmentations
+    )
+    err_msg = "KernelCPD returns different segmentations on the same signal."
+    assert all_elements_are_equal, err_msg
+
+
 @pytest.mark.parametrize(
     "algo, model",
     product(

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -329,7 +329,7 @@ def test_kernelcpd_small_signal_same_result(signal_bkps_5D_n10, kernel):
     # test if all segmentations are equal
     first_bkps = list_of_segmentations[0]
     all_elements_are_equal = all(
-        first_bkps == other_bkps for other_bkps in list_of_segmentations
+        first_bkps == other_bkps for other_bkps in list_of_segmentations[1:]
     )
     err_msg = "KernelCPD returns different segmentations on the same signal."
     assert all_elements_are_equal, err_msg


### PR DESCRIPTION
The C implementation of Pelt (`KernelCPD`) returned different segmentations when applied several times on the same signal (see #145).

This was because in the C code, we were accessing an address outside of the memory bounds of an array (something like `array[-1]` instead of `array[0]`).

I also added a test to verify that `KernelCPD` always returns the same result on the same signal.