### PR TITLE
ci: make coverage computation work

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -50,7 +50,7 @@ jobs:
         python -m pip install .[test]
     - name: Test with pytest
       run: |
-        python -m pytest --cov-report=xml --cov-report=term:skip-covered --cov=src/ruptures
+        python -m pytest --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ build-backend = "setuptools.build_meta"
 # https://docs.pytest.org/en/stable/customize.html#pyproject-toml
 [tool.pytest.ini_options]
 minversion = "6.0"
+addopts = "--cov-report=xml --cov-report=term:skip-covered"
 testpaths = ["tests"]
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,3 +64,6 @@ docs =
 
 [build_ext]
 inplace=1
+
+[coverage:run]
+source_pkgs = ruptures


### PR DESCRIPTION
Coverage reports were not uploaded to `codecov`. The PR that stops generating coverage reports is : 

* https://github.com/deepcharles/ruptures/pull/210

We noticed it while switching to the new Codecov Uploader due to depreciation of the one we were using (see [here](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) for explanations). But, I introduced an error while using the `pytest-cov` command line options. Indeed, for some reasons, what used to work does not work anymore. Seems like there are some ambiguities while specifying the path the to source to be tested if we do it at the `pytest`/`pytest-cov` level (either pointing to the sources or to the package name). 

Solution : 

* explicitly specify the package name (after installing it) as an option to `coverage` (found the doc [here](https://coverage.readthedocs.io/en/latest/config.html)).
* explicitly ask for coverage computation at command line call time (not in the config `pyproject.toml`)
