### PR TITLE
fix(datasets): propagate random seed for consistency

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install ruptures
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[test]
+        python -m pip install .[test,display]
     - name: Test with pytest
       run: |
         python -m pytest --cov

--- a/src/ruptures/datasets/pw_constant.py
+++ b/src/ruptures/datasets/pw_constant.py
@@ -1,7 +1,6 @@
 """Piecewise constant signal (with noise)"""
 
 import numpy as np
-from numpy.random import RandomState
 
 from ruptures.utils import draw_bkps
 
@@ -23,24 +22,24 @@ def pw_constant(
         tuple: signal of shape (n_samples, n_features), list of breakpoints
     """
     # breakpoints
-    bkps = draw_bkps(n_samples, n_bkps)
+    bkps = draw_bkps(n_samples, n_bkps, seed=seed)
     # we create the signal
     signal = np.empty((n_samples, n_features), dtype=float)
     tt_ = np.arange(n_samples)
     delta_min, delta_max = delta
     # mean value
     center = np.zeros(n_features)
-    rd = RandomState(seed)
+    rng = np.random.default_rng(seed=seed)
     for ind in np.split(tt_, bkps):
         if ind.size > 0:
             # jump value
-            jump = rd.uniform(delta_min, delta_max, size=n_features)
-            spin = rd.choice([-1, 1], n_features)
+            jump = rng.uniform(delta_min, delta_max, size=n_features)
+            spin = rng.choice([-1, 1], n_features)
             center += jump * spin
             signal[ind] = center
 
     if noise_std is not None:
-        noise = rd.normal(size=signal.shape) * noise_std
+        noise = rng.normal(size=signal.shape) * noise_std
         signal = signal + noise
 
     return signal, bkps

--- a/src/ruptures/datasets/pw_linear.py
+++ b/src/ruptures/datasets/pw_linear.py
@@ -1,11 +1,10 @@
 r"""Shift in linear model"""
 import numpy as np
-from numpy.random import normal
 
 from . import pw_constant
 
 
-def pw_linear(n_samples=200, n_features=1, n_bkps=3, noise_std=None):
+def pw_linear(n_samples=200, n_features=1, n_bkps=3, noise_std=None, seed=None):
     """Return piecewise linear signal and the associated changepoints.
 
     Args:
@@ -13,16 +12,21 @@ def pw_linear(n_samples=200, n_features=1, n_bkps=3, noise_std=None):
         n_features (int, optional): number of covariates
         n_bkps (int, optional): number of change points
         noise_std (float, optional): noise std. If None, no noise is added
+        seed (int): random seed
     Returns:
         tuple: signal of shape (n_samples, n_features+1), list of breakpoints
     """
-
-    covar = normal(size=(n_samples, n_features))
+    rng = np.random.default_rng(seed=seed)
+    covar = rng.normal(size=(n_samples, n_features))
     linear_coeff, bkps = pw_constant(
-        n_samples=n_samples, n_bkps=n_bkps, n_features=n_features, noise_std=None
+        n_samples=n_samples,
+        n_bkps=n_bkps,
+        n_features=n_features,
+        noise_std=None,
+        seed=seed,
     )
     var = np.sum(linear_coeff * covar, axis=1)
     if noise_std is not None:
-        var += normal(scale=noise_std, size=var.shape)
+        var += rng.normal(scale=noise_std, size=var.shape)
     signal = np.c_[var, covar]
     return signal, bkps

--- a/src/ruptures/datasets/pw_normal.py
+++ b/src/ruptures/datasets/pw_normal.py
@@ -2,29 +2,30 @@
 from itertools import cycle
 
 import numpy as np
-from numpy import random as rd
 
 from ruptures.utils import draw_bkps
 
 
-def pw_normal(n_samples=200, n_bkps=3):
+def pw_normal(n_samples=200, n_bkps=3, seed=None):
     """Return a 2D piecewise Gaussian signal and the associated changepoints.
 
     Args:
         n_samples (int, optional): signal length
         n_bkps (int, optional): number of change points
+        seed (int): random seed
 
     Returns:
         tuple: signal of shape (n_samples, 2), list of breakpoints
     """
     # breakpoints
-    bkps = draw_bkps(n_samples, n_bkps)
+    bkps = draw_bkps(n_samples, n_bkps, seed=seed)
     # we create the signal
     signal = np.zeros((n_samples, 2), dtype=float)
     cov1 = np.array([[1, 0.9], [0.9, 1]])
     cov2 = np.array([[1, -0.9], [-0.9, 1]])
+    rng = np.random.default_rng(seed=seed)
     for sub, cov in zip(np.split(signal, bkps), cycle((cov1, cov2))):
         n_sub, _ = sub.shape
-        sub += rd.multivariate_normal([0, 0], cov, size=n_sub)
+        sub += rng.multivariate_normal([0, 0], cov, size=n_sub)
 
     return signal, bkps

--- a/src/ruptures/datasets/pw_wavy.py
+++ b/src/ruptures/datasets/pw_wavy.py
@@ -2,24 +2,24 @@
 from itertools import cycle
 
 import numpy as np
-from numpy.random import normal
 
 from ruptures.utils import draw_bkps
 
 
-def pw_wavy(n_samples=200, n_bkps=3, noise_std=None):
+def pw_wavy(n_samples=200, n_bkps=3, noise_std=None, seed=None):
     """Return a 1D piecewise wavy signal and the associated changepoints.
 
     Args:
         n_samples (int, optional): signal length
         n_bkps (int, optional): number of changepoints
         noise_std (float, optional): noise std. If None, no noise is added
+        seed (int): random seed
 
     Returns:
         tuple: signal of shape (n_samples, 1), list of breakpoints
     """
     # breakpoints
-    bkps = draw_bkps(n_samples, n_bkps)
+    bkps = draw_bkps(n_samples, n_bkps, seed=seed)
     # we create the signal
     f1 = np.array([0.075, 0.1])
     f2 = np.array([0.1, 0.125])
@@ -33,7 +33,8 @@ def pw_wavy(n_samples=200, n_bkps=3, noise_std=None):
     signal = np.sum([np.sin(2 * np.pi * tt * f) for f in freqs.T], axis=0)
 
     if noise_std is not None:
-        noise = normal(scale=noise_std, size=signal.shape)
+        rng = np.random.default_rng(seed=seed)
+        noise = rng.normal(scale=noise_std, size=signal.shape)
         signal += noise
 
     return signal, bkps

--- a/src/ruptures/utils/drawbkps.py
+++ b/src/ruptures/utils/drawbkps.py
@@ -1,13 +1,13 @@
 r"""Draw a random partition."""
 
 import numpy as np
-from numpy.random import dirichlet
 
 
-def draw_bkps(n_samples=100, n_bkps=3):
+def draw_bkps(n_samples=100, n_bkps=3, seed=None):
     """Draw a random partition with specified number of samples and specified
     number of changes."""
+    rng = np.random.default_rng(seed=seed)
     alpha = np.ones(n_bkps + 1) / (n_bkps + 1) * 2000
-    bkps = np.cumsum(dirichlet(alpha) * n_samples).astype(int).tolist()
+    bkps = np.cumsum(rng.dirichlet(alpha) * n_samples).astype(int).tolist()
     bkps[-1] = n_samples
     return bkps

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -46,7 +46,7 @@ def test_seed(n_samples=200, n_features=3, n_bkps=5, noise_std=1, seed=12345):
     # pw_normal
     signal1, bkps1 = pw_normal(n_samples=n_samples, n_bkps=n_bkps, seed=seed)
     signal2, bkps2 = pw_normal(n_samples=n_samples, n_bkps=n_bkps, seed=seed)
-    assert np.isclose(signal1, signal2).all()
+    assert np.allclose(signal1, signal2)
     assert bkps1 == bkps2
 
     # pw_linear

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -40,7 +40,7 @@ def test_seed(n_samples=200, n_features=3, n_bkps=5, noise_std=1, seed=12345):
         noise_std=noise_std,
         seed=seed,
     )
-    assert np.isclose(signal1, signal2).all()
+    assert np.allclose(signal1, signal2)
     assert bkps1 == bkps2
 
     # pw_normal

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -74,7 +74,7 @@ def test_seed(n_samples=200, n_features=3, n_bkps=5, noise_std=1, seed=12345):
     signal2, bkps2 = pw_wavy(
         n_samples=n_samples, n_bkps=n_bkps, noise_std=noise_std, seed=seed
     )
-    assert np.isclose(signal1, signal2).all()
+    assert np.allclose(signal1, signal2)
     assert bkps1 == bkps2
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,7 @@
 from itertools import product
 
 import pytest
+import numpy as np
 
 from ruptures.datasets import pw_constant, pw_linear, pw_normal, pw_wavy
 
@@ -21,6 +22,60 @@ def test_constant(func, n_samples, n_features, n_bkps, noise_std):
     assert signal.shape == (n_samples, n_features)
     assert len(bkps) == n_bkps + 1
     assert bkps[-1] == n_samples
+
+
+def test_seed(n_samples=200, n_features=3, n_bkps=5, noise_std=1, seed=12345):
+    # pw_constant
+    signal1, bkps1 = pw_constant(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_bkps=n_bkps,
+        noise_std=noise_std,
+        seed=seed,
+    )
+    signal2, bkps2 = pw_constant(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_bkps=n_bkps,
+        noise_std=noise_std,
+        seed=seed,
+    )
+    assert np.isclose(signal1, signal2).all()
+    assert bkps1 == bkps2
+
+    # pw_normal
+    signal1, bkps1 = pw_normal(n_samples=n_samples, n_bkps=n_bkps, seed=seed)
+    signal2, bkps2 = pw_normal(n_samples=n_samples, n_bkps=n_bkps, seed=seed)
+    assert np.isclose(signal1, signal2).all()
+    assert bkps1 == bkps2
+
+    # pw_linear
+    signal1, bkps1 = pw_linear(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_bkps=n_bkps,
+        noise_std=noise_std,
+        seed=seed,
+    )
+    signal2, bkps2 = pw_linear(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_bkps=n_bkps,
+        noise_std=noise_std,
+        seed=seed,
+    )
+    assert np.isclose(signal1, signal2).all()
+    assert bkps1 == bkps2
+
+    # pw_wavy
+    signal1, bkps1 = pw_wavy(
+        n_samples=n_samples, n_bkps=n_bkps, noise_std=noise_std, seed=seed
+    )
+    signal2, bkps2 = pw_wavy(
+        n_samples=n_samples, n_bkps=n_bkps, noise_std=noise_std, seed=seed
+    )
+    assert np.isclose(signal1, signal2).all()
+    assert bkps1 == bkps2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -64,7 +64,7 @@ def test_seed(n_samples=200, n_features=3, n_bkps=5, noise_std=1, seed=12345):
         noise_std=noise_std,
         seed=seed,
     )
-    assert np.isclose(signal1, signal2).all()
+    assert np.allclose(signal1, signal2)
     assert bkps1 == bkps2
 
     # pw_wavy


### PR DESCRIPTION
### Description

This PR fixes an issue occurring while using the signal generation feature of `ruptures` with a random seed. Two runs with the same random seed would not return the same generated signal. 

### How to reproduces

```python
import ruptures as rpt

signal1, bkps1 = rpt.pw_constant(n_samples=200, n_features=3, n_bkps=3, noise_std=1, seed=1234)
signal2, bkps2 = rpt.pw_constant(n_samples=200, n_features=3, n_bkps=3, noise_std=1, seed=1234)

assert np.isclose(signal1, signal2).all()
assert bkps1 == bkps2
```

### Work done
 
- [x] Everywhere in `src/ruptures/datasets/` replace the use of  `numpy.random.RandomState` by `numpy.random.default_rng`
- [x] Make the random functions take the `seed` argument from the top call
- [x] adds `seed` optional argument to user exposed `pw_constant`
- [x] adds `seed` optional argument to user exposed `pw_normal`
- [x] adds `seed` optional argument to user exposed `pw_linear`
- [x] adds `seed` optional argument to user exposed  `pw_wavy`
- [x] adds `seed` optional argument to  `draw_bkps`
- [x] adds tests to check that if seed is the same between two runs, then the generated signals are the same
- [x] (Addon) adds the `display` extra option while building the package for the coverage computation in the CI (otherwise, the `display` tests are skipped because `matplotlib`  is not installed