### PR TITLE
ci: skipping wheel building for Linux 32-bit

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # Disable explicitly python 3.10 and building PyPy wheels
-          CIBW_SKIP: cp310-* pp*
+          # Disable explicitly building PyPI wheels for specific configurations
+          CIBW_SKIP: pp* cp{38,39,310}-manylinux_i686 *-musllinux_* cp310-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -52,7 +52,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: pp* cp{38,39,310}-manylinux_i686 *-musllinux_* cp310-win32
+          CIBW_SKIP: cp310-* pp* cp{38,39,310}-manylinux_i686 *-musllinux_* cp310-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"


### PR DESCRIPTION
As @oboulant explained [here](https://github.com/deepcharles/ruptures/pull/225#issuecomment-1015301852), `cibuildwheel` stopped working recently for some 32 bits setups (see also scikit-learn/scikit-learn#22122).

In this PR, wheels for cp38-manylinux_i686 and cp39-manylinux_i686 are explicitly excluded when uploading to PyPI, as well as the new `musllinux` supported by cibuildwheel (for now).

