### PR TITLE
ci: remove coverage from the wheel testing process

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -50,7 +50,7 @@ jobs:
         python -m pip install .[test,display]
     - name: Test with pytest
       run: |
-        python -m pytest --cov-report=xml --cov-report=term:skip-covered
+        python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -50,7 +50,7 @@ jobs:
         python -m pip install .[test,display]
     - name: Test with pytest
       run: |
-        python -m pytest --cov
+        python -m pytest --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -10,7 +10,7 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.overrideVersion }}
   # Run the package tests using `pytest`
-  CIBW_TEST_REQUIRES: pytest pytest-cov
+  CIBW_TEST_REQUIRES: pytest
   CIBW_TEST_COMMAND: pytest {project}/tests
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 # https://docs.pytest.org/en/stable/customize.html#pyproject-toml
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--cov-report=xml --cov-report=term:skip-covered"
+addopts = "-vv"
 testpaths = ["tests"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Pytest coverage is useless when testing wheels.