### PR TITLE
docs: pw_normal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
   hooks:
     - id: nbstripout
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
     - id: blacken-docs
 - repo: https://github.com/nbQA-dev/nbQA

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
   hooks:
     - id: nbstripout
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: v1.12.0
     hooks:
     - id: blacken-docs
 - repo: https://github.com/nbQA-dev/nbQA

--- a/docs/user-guide/datasets/pw_normal.md
+++ b/docs/user-guide/datasets/pw_normal.md
@@ -17,8 +17,8 @@ import matplotlib.pylab as plt
 import ruptures as rpt
 
 # creation of data
-n = 500, 3  # number of samples
-n_bkps = 3  # number of change points, noise standart deviation
+n = 500  # number of samples
+n_bkps = 3  # number of change points
 signal, bkps = rpt.pw_normal(n, n_bkps)
 rpt.display(signal, bkps)
 ```


### PR DESCRIPTION
This is just a small change in the docs of `pw_normal`. The line `n = 500, 3  # number of samples` is not working.
```Python
import numpy as np
import matplotlib.pylab as plt
import ruptures as rpt

# creation of data
n = 500, 3  # number of samples
n_bkps = 3  # number of change points, noise standart deviation
signal, bkps = rpt.pw_normal(n, n_bkps)
rpt.display(signal, bkps)
```
->

```Python
import numpy as np
import matplotlib.pylab as plt
import ruptures as rpt

# creation of data
n = 500  # number of samples
n_bkps = 3  # number of change points
signal, bkps = rpt.pw_normal(n, n_bkps)
rpt.display(signal, bkps)
```