### PR TITLE
docs(typo): Fixed syntax errors

### DIFF
--- a/docs/user-guide/detection/pelt.md
+++ b/docs/user-guide/detection/pelt.md
@@ -35,7 +35,7 @@ algo = rpt.Pelt(model=model, min_size=3, jump=5).fit(signal)
 my_bkps = algo.predict(pen=3)
 
 # show results
-fig, ax = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))
+fig, ax_arr = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))
 plt.show()
 ```
 

--- a/docs/user-guide/detection/pelt.md
+++ b/docs/user-guide/detection/pelt.md
@@ -27,7 +27,7 @@ import ruptures as rpt
 # creation of data
 n, dim = 500, 3
 n_bkps, sigma = 3, 1
-signal, b = rpt.pw_constant(n, dim, n_bkps, noise_std=sigma)
+signal, bkps = rpt.pw_constant(n, dim, n_bkps, noise_std=sigma)
 
 # change point detection
 model = "l1"  # "l2", "rbf"
@@ -35,7 +35,7 @@ algo = rpt.Pelt(model=model, min_size=3, jump=5).fit(signal)
 my_bkps = algo.predict(pen=3)
 
 # show results
-fig, (ax,) = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))
+fig, ax = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))
 plt.show()
 ```
 


### PR DESCRIPTION
The breakpoint variable, 'bkps' was mispelt to 'b' in the line below
`signal, b = rpt.pw_constant(n, dim, n_bkps, noise_std=sigma)`
This resulted in in error when trying to display the true and estimated breakpoints
Also the plotting function has extra brackets and a comma as seen below
`fig, (ax,) = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))`
This resulted in an integer iteration error. The fix(which encoprates the bkps spelling fix as well) is shown below
`fig, ax = rpt.display(signal, bkps, my_bkps, figsize=(10, 6))`