### PR TITLE
fix(CostL2): set min_size to 1

### DIFF
--- a/src/ruptures/costs/costl2.py
+++ b/src/ruptures/costs/costl2.py
@@ -15,7 +15,7 @@ class CostL2(BaseCost):
     def __init__(self):
         """Initialize the object."""
         self.signal = None
-        self.min_size = 2
+        self.min_size = 1
 
     def fit(self, signal) -> "CostL2":
         """Set parameters of the instance.

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -78,6 +78,8 @@ def test_costs_1D_noisy_names(signal_bkps_1D_noisy, cost_name):
         if cost_name == "cosine":
             cost.min_size = 4
             cost.error(1, 2)
+        elif cost_name == "l2":
+            cost.error(1, 1)
         else:
             cost.error(1, 2)
 
@@ -105,6 +107,8 @@ def test_costs_5D_names(signal_bkps_5D, cost_name):
         if cost_name == "cosine":
             cost.min_size = 4
             cost.error(1, 2)
+        elif cost_name == "l2":
+            cost.error(1, 1)
         else:
             cost.error(1, 2)
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -126,6 +126,8 @@ def test_costs_5D_noisy_names(signal_bkps_5D_noisy, cost_name):
         if cost_name == "cosine":
             cost.min_size = 4
             cost.error(1, 2)
+        elif cost_name == "l2":
+            cost.error(1, 1)
         else:
             cost.error(1, 2)
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -104,7 +104,7 @@ def test_costs_5D_names(signal_bkps_5D, cost_name):
     cost.error(10, 50)
     cost.sum_of_costs(bkps)
     if cost_name == "l2":
-            assert cost.error(1, 2)==0., "CostL2 on segment of size 1 returns 0."
+        assert cost.error(1, 2) == 0.0, "CostL2 on segment of size 1 returns 0."
 
     with pytest.raises(NotEnoughPoints):
         if cost_name == "cosine":

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -103,6 +103,9 @@ def test_costs_5D_names(signal_bkps_5D, cost_name):
     cost.error(100, signal.shape[0])
     cost.error(10, 50)
     cost.sum_of_costs(bkps)
+    if cost_name == "l2":
+            assert cost.error(1, 2)==0., "CostL2 on segment of size 1 returns 0."
+
     with pytest.raises(NotEnoughPoints):
         if cost_name == "cosine":
             cost.min_size = 4

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -58,6 +58,8 @@ def test_costs_1D_names(signal_bkps_1D, cost_name):
         if cost_name == "cosine":
             cost.min_size = 4
             cost.error(1, 2)
+        elif cost_name == "l2":
+            cost.error(1, 1)
         else:
             cost.error(1, 2)
 


### PR DESCRIPTION
The `min_size` parameter was set to 2 for CostL2 and produced bad segmentations for small signals (see Issue #242).

Now it is set to 1 by default.
