### PR TITLE
ci(docs): fix the doc publishing job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,11 @@ testpaths = ["tests"]
 
 [tool.setuptools_scm]
 write_to = "src/ruptures/version.py"
+
+# PEP 621 dependencies declaration
+# adapt to your dependencies manager
+[project]
+dependencies = [
+    "mkdocstrings[python]>=0.18", # https://mkdocstrings.github.io/handlers/overview/#about-the-python-handlers
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,3 @@ testpaths = ["tests"]
 
 [tool.setuptools_scm]
 write_to = "src/ruptures/version.py"
-
-# PEP 621 dependencies declaration
-# adapt to your dependencies manager
-[project]
-dependencies = [
-    "mkdocstrings[python]>=0.18", # https://mkdocstrings.github.io/handlers/overview/#about-the-python-handlers
-]
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ docs =
     mkdocs-macros-plugin
     mkdocs-material
     mkdocs-section-index
-    mkdocstrings
+    mkdocstrings[python]>=0.18 # https://mkdocstrings.github.io/handlers/overview/#about-the-python-handlers
     mknotebooks
     pymdown-extensions
     nltk


### PR DESCRIPTION
The job that publishes the documentation online raises an error (see below). It seems that some changes `mkdocstrings` are causing this (https://mkdocstrings.github.io/handlers/overview/#about-the-python-handlers).

```
Run mkdocs build
INFO     -  [macros] - Macros arguments: {'module_name': 'mkdocs_macros', 'modules': [], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '', 'on_undefined': 'keep', 'on_error_fail': False, 'verbose': False}
INFO     -  [macros] - Found local Python module 'mkdocs_macros' in: /home/runner/work/ruptures/ruptures
INFO     -  [macros] - Found external Python module 'mkdocs_macros' in: /home/runner/work/ruptures/ruptures
INFO     -  [macros] - Extra filters (module): ['pretty']
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /home/runner/work/ruptures/ruptures/site
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - user-guide/evaluation.md
ERROR    -  Error reading page 'code-reference/base-reference.md': No module named 'mkdocstrings.handlers.python'
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocstrings/handlers/base.py", line 563, in get_handler
    module = importlib.import_module(f"mkdocstrings_handlers.{name}")
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocstrings_handlers'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocs/__main__.py", line 192, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocs/commands/build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocs/commands/build.py", line 174, in _populate_page
    page.render(config, files)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocs/structure/pages.py", line 175, in render
    self.content = md.convert(self.markdown)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocstrings/extension.py", line 121, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocstrings/extension.py", line 175, in _process_block
    handler = self._handlers.get_handler(handler_name, handler_config)
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/mkdocstrings/handlers/base.py", line 565, in get_handler
    module = importlib.import_module(f"mkdocstrings.handlers.{name}")
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocstrings.handlers.python'
Error: Process completed with exit code 1.
```