### PR TITLE
docs: fix text segmentation notebook

### DIFF
--- a/docs/examples/text-segmentation.ipynb
+++ b/docs/examples/text-segmentation.ipynb
@@ -33,15 +33,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:13.117941Z",
-     "iopub.status.busy": "2023-03-28T12:51:13.117616Z",
-     "iopub.status.idle": "2023-03-28T12:51:13.932607Z",
-     "shell.execute_reply": "2023-03-28T12:51:13.932247Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -62,26 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:13.934081Z",
-     "iopub.status.busy": "2023-03-28T12:51:13.933930Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.163280Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.162615Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[nltk_data] Downloading package stopwords to\n",
-      "[nltk_data]     /Users/oboulant/nltk_data...\n",
-      "[nltk_data]   Package stopwords is already up-to-date!\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "nltk.download(\"stopwords\")\n",
     "STOPWORD_SET = set(\n",
@@ -99,15 +75,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.196707Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.196549Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.199491Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.199164Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def preprocess(list_of_sentences: list) -> list:\n",
@@ -125,15 +94,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.200948Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.200820Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.203493Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.203218Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def draw_square_on_ax(start, end, ax, linewidth=0.8):\n",
@@ -176,24 +138,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.204919Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.204796Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.207578Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.207287Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "There are 99 sentences, from 10 documents.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Loading the text\n",
     "filepath = Path(\"../data/text-segmentation-data.txt\")\n",
@@ -214,32 +161,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.208898Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.208780Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.211053Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.210778Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10: That could be easily done , but there is little reason in it .\n",
-      "11: It would come down to saying that Fromm paints with a broad brush , and that , after all , is not a conclusion one must work toward but an impression he has from the outset .\n",
-      "12: the effect of the digitalis glycosides is inhibited by a high concentration of potassium in the incubation medium and is enhanced by the absence of potassium ( Wolff , 1960 ) .\n",
-      "13: B. Organification of iodine The precise mechanism for organification of iodine in the thyroid is not as yet completely understood .\n",
-      "14: However , the formation of organically bound iodine , mainly mono-iodotyrosine , can be accomplished in cell-free systems .\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# print 5 sentences from the original text\n",
     "start, end = 9, 14\n",
-    "for (line_number, sentence) in enumerate(original_text[start:end], start=start + 1):\n",
+    "for line_number, sentence in enumerate(original_text[start:end], start=start + 1):\n",
     "    sentence = sentence.strip(\"\\n\")\n",
     "    print(f\"{line_number:>2}: {sentence}\")"
    ]
@@ -260,28 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.212348Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.212236Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.231142Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.230888Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Original sentence:\n",
-      "\tThen Heywood Sullivan , Kansas City catcher , singled up the middle and Throneberry was across with what proved to be the winning run .\n",
-      "\n",
-      "Transformed:\n",
-      "\theywood sullivan kansa citi catcher singl middl throneberri across prove win run\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# transform text\n",
     "transformed_text = preprocess(original_text)\n",
@@ -296,25 +205,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.232248Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.232166Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.236153Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.235917Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "There are 842 different words in the corpus, e.g. ['acid' 'across' 'act' 'activ' 'actual' 'ad' 'adair' 'addit' 'administ'\n",
-      " 'administr'].\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Once the text is preprocessed, each sentence is transformed into a vector of word counts.\n",
     "vectorizer = CountVectorizer(analyzer=\"word\")\n",
@@ -373,15 +266,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.237418Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.237339Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.240092Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.239864Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "class CosineCost(BaseCost):\n",
@@ -431,25 +317,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.241192Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.241111Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.501297Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.500970Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "True change points are\t\t[11, 20, 30, 40, 49, 59, 69, 80, 90, 99].\n",
-      "Detected change points are\t[12, 19, 30, 40, 49, 59, 70, 78, 94, 99].\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "n_bkps = 9  # there are 9 change points (10 text segments)\n",
     "\n",
@@ -486,68 +356,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.502717Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.502627Z",
-     "iopub.status.idle": "2023-03-28T12:51:14.505701Z",
-     "shell.execute_reply": "2023-03-28T12:51:14.505416Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Paragraph n°01\n",
-      "(true)\t01 02 03 04 05 06 07 08 09 10 11   \n",
-      "(pred)\t01 02 03 04 05 06 07 08 09 10 11 12\n",
-      "\n",
-      "Paragraph n°02\n",
-      "(true)\t12 13 14 15 16 17 18 19 20\n",
-      "(pred)\t   13 14 15 16 17 18 19   \n",
-      "\n",
-      "Paragraph n°03\n",
-      "(true)\t   21 22 23 24 25 26 27 28 29 30\n",
-      "(pred)\t20 21 22 23 24 25 26 27 28 29 30\n",
-      "\n",
-      "Paragraph n°04\n",
-      "(true)\t31 32 33 34 35 36 37 38 39 40\n",
-      "(pred)\t31 32 33 34 35 36 37 38 39 40\n",
-      "\n",
-      "Paragraph n°05\n",
-      "(true)\t41 42 43 44 45 46 47 48 49\n",
-      "(pred)\t41 42 43 44 45 46 47 48 49\n",
-      "\n",
-      "Paragraph n°06\n",
-      "(true)\t50 51 52 53 54 55 56 57 58 59\n",
-      "(pred)\t50 51 52 53 54 55 56 57 58 59\n",
-      "\n",
-      "Paragraph n°07\n",
-      "(true)\t60 61 62 63 64 65 66 67 68 69   \n",
-      "(pred)\t60 61 62 63 64 65 66 67 68 69 70\n",
-      "\n",
-      "Paragraph n°08\n",
-      "(true)\t70 71 72 73 74 75 76 77 78 79 80\n",
-      "(pred)\t   71 72 73 74 75 76 77 78      \n",
-      "\n",
-      "Paragraph n°09\n",
-      "(true)\t      81 82 83 84 85 86 87 88 89 90            \n",
-      "(pred)\t79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94\n",
-      "\n",
-      "Paragraph n°10\n",
-      "(true)\t91 92 93 94 95 96 97 98 99\n",
-      "(pred)\t            95 96 97 98 99\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "true_segment_list = rpt.utils.pairwise([0] + TRUE_BKPS)\n",
     "predicted_segment_list = rpt.utils.pairwise([0] + predicted_bkps)\n",
     "\n",
-    "for (n_paragraph, (true_segment, predicted_segment)) in enumerate(\n",
+    "for n_paragraph, (true_segment, predicted_segment) in enumerate(\n",
     "    zip(true_segment_list, predicted_segment_list), start=1\n",
     "):\n",
     "    print(f\"Paragraph n°{n_paragraph:02d}\")\n",
@@ -584,27 +400,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:14.506909Z",
-     "iopub.status.busy": "2023-03-28T12:51:14.506819Z",
-     "iopub.status.idle": "2023-03-28T12:51:15.032564Z",
-     "shell.execute_reply": "2023-03-28T12:51:15.032270Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABK8AAAKACAYAAABaLls9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAB7CAAAewgFu0HU+AADAVUlEQVR4nOzdd3gUZdfH8d+SRhJCQIoECU2KDUGkWxAUsCMqAlJFUbHCI4L4gIhIFcSCiIgURQQFpdiwUEWQrvBY6JpgKAokEJJAknn/4M2S5Z4km2Q3uxu+n+vKde2euWfmbD+5d/aMw7IsSwAAAAAAAIAfKuHrBAAAAAAAAICcMHkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAA5MOLL74oh8Mhh8Ph61QAwO+sWLHC+R65YsUKY3mvXr3kcDhUvXr1Is/NV2644QY5HA7dcMMNvk4FgKR9+/Y536dmzpzp63TgJiavUGxkfxMqzB8AAIC3ZZ/kOfcvIiJC1apV01133aU5c+YoPT3d1+kCAOBTTF4BxVygfcNZvXp1ORwO9erVy9epwIfy+ube02bOnOnc3759+7y+PwDITUpKiv766y8tWrRIXbt2VYsWLXTgwAFfp+X3Aq3mcVdRfyYWFkcoI0tR1/VZz7sXX3yxSPaHohXs6wQAT7nooou0bdu2HJfXq1dPktSoUSPNmDGjqNICUMy8+OKLFEUAPKpv37567LHHnNdPnDihjRs3asKECdq3b582bNig9u3ba926dQE/ITBz5kx+pgPAp6pXry7LsnydBvKJySsUGyEhIbriiivyHBcZGenWOAAAgKJQsWJFozZp1qyZunbtqiZNmmjXrl1av369Pv/8c91xxx0+yhIAAN/hZ4MAAACAHypbtqwGDx7svP7111/7MBsAAHyHyStA5llgdu7cqSeeeEK1a9dWRESESx8cd3vj5OcsFgsXLlTHjh1VtWpVlSxZUmXKlFGjRo00fPhwHT16tEC3KavfwKxZsyRJf/75p9sN6lNTUzVp0iTdeOONqlSpkkJDQ1WxYkXddNNNeu+992wbx/7www8KCgqSw+HQbbfdlmNeSUlJqlGjhhwOhypWrKiDBw9KOvsY/Pnnn5KkWbNmGbkW5Cw9qampeuONN3TDDTeoQoUKCgkJ0QUXXKC6devqlltu0auvvprr45iRkaFZs2bp9ttvV+XKlRUWFqZy5crp2muv1auvvqqUlJQ8c9i+fbt69OihKlWqqGTJkqpataq6deumzZs3S8q9R4fd8+jTTz9V27ZtVbFiRUVGRqp+/fp68803dfr0aed6lmVpzpw5uuGGG1SxYkVFRESoYcOGmjJliluHSScmJmr06NG65pprVKFCBYWGhiomJkZ33HGH5s+fn+s2zu03sGHDBnXp0kVVqlRRWFiYLrroInXv3l2//fZbjre3VatWzlirVq2M58K5r6nt27fr5ZdfVrt27Zz7KVWqlGrXrq2ePXtq3bp1trlm9RF54IEHnLGs52f2v+w9Rtzt5bFv3z71799fl19+uaKiohQREaHatWvrkUceyfUnzoW9DwEUL02aNHFezvqMlMw+SJmZmZo+fbpatWqlCy+8UCVKlLDtM7N582Y9+uijqlu3rkqVKqXIyEjVrVtXffv21Y4dO/LMJyUlRaNGjVL9+vUVGRmpcuXK6ZprrtG7776rzMzMPNd3ty/V8ePHNWHCBLVu3dpZi5QuXVpXXXWVnnzySa1Zs8Y5tqhrnnOtW7dOHTt2VKVKlVSyZEnVqFFDDz/8sP744488181NQT8Tsyxfvlw9e/ZUzZo1FRERodKlS6tevXp69tln9ffffxvj09LSdOWVV8rhcCgqKkp79uzJMbf//Oc/zv1ntePIqpGHDx/uHGf3OBSkt+SyZcvUpUsX1ahRQ+Hh4c6TGjRr1kwDBgzQsmXLcl2/sM/7kydPasSIEbryyiudz/trr71W06dPl2VZefYlO/d/jV27dunRRx9VzZo1FR4erurVq+vBBx90eY1LZ+qbBx54QDVr1lTJkiUVGxurvn376tChQ27dbwX9H+Pc1+mxY8f0wgsv6PLLL1dkZKTKlCmj66+/Xh9++KHt+gWp648ePaoZM2aoW7duuuyyy1SqVCmFhoaqUqVKateunaZOnapTp07Z7i+rt1aW4cOHG/vL/n7o7v9pp06d0uTJk9WqVStnPVypUiXdeuutmj17dq7veYW9D2HDAs4TkixJVsuWLY1lLVu2dC5buHChFRkZ6Ryf9bd3717LsixrxowZRszO3r17neNmzJhhO+bIkSNW69atjX1l/6tYsaK1du3afN/eYcOG5brdrL9zbd261apWrVqu6zRu3Ng6cOCAse7zzz/vHPPWW2/Z5tWtWzfnmMWLFzvjWY9Bbn92j11u/v77b+uyyy7Lc7vPPPOM7fp//vmnVb9+/VzXrVWrlvXHH3/kmMMHH3xghYSE2K4bEhJizZw50+rZs6clyapWrZqx/rnPo759++aYy913322lp6dbqamp1r333pvjuD59+uR6v3333XdWuXLlcr3dt956q3X8+HHb9bPGDBs2zHrrrbes4OBg221ERERYK1euzPH25vaX/TW1fPlyt9Z57rnnjFzdXXf58uXOdbK/tnIya9YsKywsLMftBQUFWaNGjcpx/cLchwACQ/b3n2HDhuU47vfff3eOu/nmm23X/+qrr6ybbrrJeI/o2bOnc3xGRobVv39/y+Fw5PjeFBwcbL3zzjs55pKQkGBdeumlOa7frl07a+nSpbbvnVly+8zL8u2331rly5fP8705iy9qniyvvvqqVaJECdt1IyMjrS+++MKlzsyPgnwmWpZlpaSkWJ07d851ncjISJc6LMsvv/zi/Pxq3ry5lZ6eboz59ttvnc+je+65xxnPXiPn9pdb/WynX79+eW6zXLlytut64nkfFxdn1a5dO8f1b7/9duubb77J9Xmf/Tnw7bffWlFRUbbbqlixovXbb79ZlmVZc+bMsUJDQ23HVatWzdq/f3+OORf2f4zsr9Pff//dql69eo7befzxx3O8vbn9nft6yOu1KMm66qqrrISEBGN/7qyb/f3Qnf/T9u7da11yySW5bvPaa6+1/v33X6/chzAxeYXzRk5vlJZ19g22Ro0aVqlSpawKFSpYY8aMsdasWWOtW7fOevPNN63Dhw9bluW5yavU1FSrYcOGlnTmH9nu3btbH330kbVu3Tpr9erV1siRI50TCGXLlrX27duXr9t78OBBa9u2bVb79u0tSVblypWtbdu2GX/Z7dy504qOjrYkWaVLl7YGDx5sffbZZ9bGjRutpUuXWo8//rjzn+imTZtap06dcln/1KlTVqNGjSxJVnh4uPPDN8tHH33kvE8eeeQRl2V79uyxtm3bZlWuXNmSZLVv397Idc+ePfm6D+655x7n/rp162Z9+umn1rp166wNGzZYixcvtl544QWrfv36tpNX//zzjxUbG2tJssLCwqwnnnjC+uSTT6wNGzZYy5cvtwYPHmxFRERYkqyaNWtax44dM7axZs0aKygoyJLOTDIMGTLEWrVqlfXTTz9Zb731llWlShUrNDTUuuqqq5wfbufK/jxq2rSpJZ2ZOPr000+tTZs2WQsXLnTGJVnvvvuu9eSTT1qSrPvvv9/6/PPPrU2bNllz5851+QD+6quvbO+zH374wTnZduGFF1ovv/yytWTJEmvTpk3WkiVLXCYf7777btttZC1v1qyZVaJECat+/frW9OnTrQ0bNlirVq2y+vfv7yz0q1ataqWlpTnXPXXqlLVt2zZr+vTpzu1Mnz7deC4cPXrUuc63335rRUZGWvfdd581ZcoUa8WKFdbmzZutr7/+2powYYJLQTN9+nSXXE+cOGFt27bNevnll51jli5dauzvxIkTznXymrz6/PPPnUVyqVKlrGHDhlmrV6+21q5da02YMMHlH7LJkyd7/D4EEBjcnbz65JNPnON69+5tu/6VV15pSbLuvPNO5+fDl19+ac2dO9c5/rHHHnOOv/76663p06dbK1assNavX2+9++671uWXX+5cvmjRIiOP06dPW1dffbVzTNu2bZ01wqeffuqcPGvcuLFzTEEmr5YtW+asNYKCgqxevXpZn332mbVp0yZrzZo11rvvvmvdfffdVkhIiHMdX9Q8lmVZn376qfO2RkdHW6NGjbJ+/PFH68cff7Refvllq3Tp0laZMmWcEx/5nbwqyGdiZmamddtttznH33HHHdYHH3xgrVmzxlq7dq31+uuvW1WrVrUkWaGhodaGDRuM/U6cONG5/osvvuiy7N9//3XWapUrV7b++ecf57KjR49a27Ztc/mize5xsLsvc7JkyRKX5/nbb79trVixwtqyZYu1fPlya9KkSdZdd91lVa5c2Xb9wj7vT5065Xx9SbJuu+02a+HChdbGjRuthQsXWrfeeqtLjZbT8z7rf43atWtbZcuWtWJjY60333zT+umnn6zVq1db/fr1c9YO11xzjbV+/XorODjYuvTSS61p06ZZ69evt5YvX251797duZ9OnTrZ3mZP/I+R9TqtUKGCVbt2bSsqKsoaMmSItWLFCmvjxo3Wu+++a1WpUsWZy9dff+2yfkHq+ipVqlhNmza1RowYYX3++efWhg0brDVr1lizZ8+2br755lz/l/vjjz+sbdu2Ocf07dvX2F98fLxzfF7/px0/ftyqWbOmc8xdd91lLV682Nq4caP1ySefuEzOtWjRwnaSt7D3IUxMXuG84c7kVdYH8Z9//pnjdjw1eZV1lFKZMmWsjRs32m5j3759VkxMjHMioiDc+YYzS4sWLSzpzLcaWZN15/rqq6+c/zRPnTrVWP7HH384J3Wuuuoq5z/Vf/31l1WmTBlLklWnTh0rOTnZdvtZEw3Zvx0piJSUFOckTE5HVmWx+8bk/vvvd95vOU2abd682XmU3vPPP28sb9CggXPya926dcbygwcPunww5jV5Jcnq16+fMSY5Odl5v5UrV85yOBzWa6+9ZoxLSEhwftN35513GstPnTrl/Fbo5ptvzvExmjp1qjOfb775xliePd9bb73VdmIl+2TRp59+aizP/k+ZXRGY3eHDh10K93OlpaVZbdq0cd7HdgWGu69ry8p98urUqVPOQq1UqVLWli1bjDHZX9cRERG2rzVP3IcA/Js7k1enT5+2mjVr5hz3/vvv264vyRoyZEiO+8p+VMi0adNsx6SkpDiP1KhWrZp1+vRpl+WTJk1ybuPhhx+23Ubv3r1dcsrv5FVKSorzPTQiIiLX9/+//vorX9s+V2FrnrS0NGeu0dHR1q+//mqsv23bNqt06dK51qDuyM9nYtZndEhISI5fVB05csQ5aXPNNdcYyzMzM52fm8HBwS5H59x9992WJMvhcNjWAJbl3hHK7sqarKlWrVqOR3xbln0t54nn/WuvvZZrDWZZlvXEE0/k+bzP/r9G7dq1rUOHDhljBgwY4BxToUIFq0WLFra1WMeOHZ2Pjd12PPE/RtZrKev5vX37dmPMzp07rZIlS+ZYV1pW/ur6HTt25Lo8+yTud999Zzsmr/fULHn9n5b9sbB7b83MzLS6du3qHGP3ZaSn7kOcxeQVzhvuTl5lLwzteGLy6vjx485v+958881c9zd58mRnEZL96A93uVvIrVq1ypnvL7/8kuvY++67z5LOfNNg55133nFua+DAgVZGRobzPg4JCbH9li+Lpyav9u/f78zB7pu03Ozdu9d5xNSSJUtyHTtw4EBLkvGN37p165z7HzBgQI7rL1q0yO3Jq9jY2By/rXzhhRec45o1a5bj/nr06GFJZ75pO9f7779vSbJKlixpWwxl16RJkxwLnqw8SpYsaR08eNB2/aSkJOeh8P379zeW56dQd8fWrVud27Mr5Dw1eTVv3jznsjFjxuS4jdmzZzvHjRs3zljuifsQgH/LbfLqxIkT1ooVK6wbbrjB5TMiNTXVdv06derYTsxnyfrnPPtPvOz8+uuvzm2eOzGR9TP8Cy+8MMcvN44fP25VqFChwJNX2esHuy9h8lKUNc/HH3/s3Mb48eNzXH/s2LFFNnmVmZlpXXzxxZaU9xd3X375pXObdpMG+/fvdx6dc/HFF1vHjx+33nvvvTwncizLs5NXWZNoHTp0yPe6nnjeZx21XqVKFZfXX3YnT550TmS6M3mV06Tinj17nGMcDofthKhlnTk6Maca11P/Y2SfeHnjjTdy3EbWz1MvuOAC2+WequuzZH0x/MQTT9gu98TkVWpqqvML98svvzzH99bExETna+Syyy4zlnvqPsRZNGwHsgkNDVXHjh29vp+VK1cqMTFRknTvvffmOvb666+XJJ0+fVqbNm3yWk6LFy+WJNWtW1f16tVzK6cNGzbYNjJ9+OGHdeedd0qSxo8fr/vvv18rV66UJA0bNkyNGjXyZOq2ypUrp9DQUEnSBx984FbD1SxffPGFMjIyFBERoVtuuSXXsVn3xd9//62//vrLGf/uu++cl7t3757j+rfddpvKlSvnVl533323QkJCbJfVr1/feblTp045biNr3NGjR3Xs2DGXZVnPgZYtW6pChQq55pJ1u9euXZvjmDZt2qhixYq2y6KiolS7dm1JyrUhbEGkpaXpr7/+0q+//qrt27dr+/btLg3mf/75Z4/uL7usx93hcKh37945juvYsaOio6Nd1rHjq/sQQNE6t7lwqVKldMMNNzgbP1esWFELFy5UWFiY7fqdOnVSUFCQ7bKkpCTndvKqOS699FKVL19ekuv7e0JCgn799VdJ0n333aeIiAjb9UuVKqX77rsv133k5vPPP5ckRUZGqk+fPgXeTl48UfNkf7/v2bNnjus/8MADeZ7gw1N+/fVX7d69W5L79aVk/1leuXJlvfvuu5Kk3bt36/7779fTTz8tSbriiis0ZswYT6Wdq5iYGEnSqlWrnLfNHZ543u/fv1+///67pDOf2zm9/sLDw93+/6FMmTJq166d7bIaNWooKipKknTllVfq0ksvtR2XveY79/Pf0/9jOBwO3X///Tlu4+qrr5YkHTlyxKgrC8OyLB04cEA7duxw1nLbt2/XRRddJMm7tdymTZuct6VXr145vreWLl3a+X7366+/KiEhwXacr+7D4ojJKyCb2rVrq2TJkl7fz8aNG52XY2JibM/EkvV3xRVXOMceOHDA6zn98ccfuebjcDj0xBNPSDrzYXfkyBHb7U2bNk2VKlVSZmam5s2bJ0m69tpr9dxzz3ntNmQXFhbmnMSZP3++atWqpYEDB+rLL7/M84Mh6744efKkgoODc70vbr/9dud62R+f7du3O/O4/PLLc9xXUFCQGjRo4NZtqlOnTo7LypQpk+9xx48fd1mWdbuXLl2a53Ng/PjxknJ/Tl5yySW53RxdcMEFtnkURHJyskaPHu08+1W1atV0+eWXq169eqpXr56uuuoq59h//vmn0PvLSdbjXqNGjVwnAENDQ505Za1jpyjvQwD+p0aNGnr22We1bdu2XD8rrrzyyhyXbdmyxXlGrC5duuT5/p71Hpn9/T37GVIbN26ca87Zz46YX1u2bJF05p+5nCbIPMETNU/WfVKjRg3nxIedChUq5HlmRU/JXl82b94819tVqlQp59icPss7dOigBx98UJK0ZMkSnThxQmFhYfrwww9znMjxtB49ekiS/v33X11xxRXq3LmzZsyYoV27duW6niee99k/n7MmGHLi7heztWvXznUyM6tOK2wtJ3nmf4zy5cvn+iVrVh1il0tBfPHFF7r99tsVHR2tmJgY5wRz1t8XX3whqWhqOUlq2rRprmOzL8+pnivq+7A4Y/IKyKZs2bJFsh93T297rpMnT3o4k7M8nVOFChU0evRo5/WQkBB98MEHOX574Q2TJk3SHXfcIenMabNfeeUV55FOjRs31iuvvOL8dio7T9wXWacfvuCCC/K8zXkd5ZQlt0K+RIkS+R6XkZHhsqwgtzslJSXHZXn945GVy7l55Ne+fftUr149Pf/88/rll1/y3F5uORdW1j82OR0tlV2lSpVc1rFTVPchAN/q27evtm3bpm3btmn79u3atWuXjh07pj179mjcuHF5vqfkVr944jMt+/tUXrlceOGFBdqfdPYf0qyjbbzFk/eJO+/3hblP8sMb9eXEiRNdJrpeeOGFXCdLPe3GG2/UpEmTFB4ertTUVM2bN0+9e/dW7dq1VaVKFT366KO2R+F4spaT8q7VPFHLSWc/14uylpNyfg64m69dLvlhWZYeeugh3X777friiy/ynMQpilpOyvv1nVXLnbtedkV1H54Pgn2dAOBPimpiJfsb0+bNm3P8Kdi5qlSp4q2UnDnVr19fs2fPdnu9rMN3z5Wenq63337bef306dNasWKFevXqVag886N06dJavHix1q9fr48//lgrVqzQ1q1blZGRoY0bN2rjxo0aP368Fi5cqObNmzvXy7ovypcvr+XLl7u9vxo1anj8NhSlrNt9yy23aNy4cT7Oxn3du3fX3r175XA49MADD6hz58669NJLVaFCBYWGhsrhcCgzM9P5+s7+E0JvKaqfiAAoHipWrOhyFER+5Va/ZK853nnnHbVo0cKtbeY0IVYc3t88WfP40/2R/bFesmSJ20d85fYP+owZM3TixAnn9e+++06DBw8u0tv9+OOPq2PHjpozZ46+/fZbrVmzRomJidq/f7/eeecdTZ06Vc8//7xefvll5zqeft4HCn/8H8Md06dP13vvvSdJatCggfr166emTZvqoosuUkREhPM9rkePHvrggw+KpJaT/Ov1DSavgHzLPjuedTiyneTk5ByXZT90tEKFCj7/wJDO5nTixIlCFdBZXnrpJa1fv17SmUmkpKQkPfXUU2rZsmWRT/I0adLE+TOG48ePa8WKFZo5c6Y+/fRTHTp0SPfcc492796t8PBwSWfvi+PHj+vSSy8t0KRmVvFz5MgRZWRk5LqNw4cP53v73lCuXDn9/fffOnXqlEeeA0Xh999/1w8//CBJRuGaXW5HN3lS1qHfBw8ezHNs1iH62Q8XBwBPy15zREREFOj9Pfs/9Hm9v7nz/peT8uXLKz4+PsfeMZ7iiZon6z5x5/YW5j7Jj+yPdZkyZQr9Wf7rr79q0KBBks7WcsuXL9eECRM0YMCAQm07vypWrKh+/fqpX79+yszM1NatW/XZZ59p0qRJOnbsmEaOHKnGjRurffv2kjz/vM+rVvOnWi6Lv/yP4Y6s/mq1atXSjz/+6KzJz1UU9Vz2uuzgwYO5/oQz+88tqee8j58NAvmU1UhRcj2c+Fw7duzIcVn2/jtr1qzxTGI5cPcbg6yc9uzZU+jeWmvXrtWoUaMkSW3bttWyZcsUEhKi48ePq3v37rkeEuvtbziioqJ0xx13aMGCBXrqqacknWlEmzUBIp29L9LS0lx6B+RHVp+rtLQ0/e9//8txXEZGhrZu3VqgfXha1u3euHGjTp065dNc3H0eZL9vc2tUn9fj6KnnXVZxvHfv3lwL2dOnTzt7uwTKRCGAwNSgQQPne1xBa47sTc03bNiQ69i8luemYcOGks68ZxekVUJR1jxZ98nevXv177//5jju8OHD2rdvX4H2kSW/t0sqfH156tQpde3aVampqYqIiNDatWud/X2GDBmiX375pdD5FlSJEiXUsGFDjRgxQt9//70z/vHHHzsve+J5n71naV4nTSpovehpRfk/hjvyW8/deeedOU5cWZalzZs3eyy3nGSvy3766adcx2Z9UX/uevAOJq+AfMp+1FBuH1QfffRRjstuuukm5++f33jjDa8e+prVgD4tLS3XcVlnB7QsS6+//nqB93fixAl169ZNGRkZKleunGbMmKGrr75aI0aMkHTmgzS3M9S4m68n3Hjjjc7L2Rs/3nHHHc4P29dee63Q2/7ggw9yHPfFF1/kWvQWpaznQGJiombMmOHTXLKfOCG350L2Mz/ldrTjlClTPLK/vNx0002SzryOcrsP58+f7+y3lrUOAHhDhQoV1KxZM0nSnDlzCnSESOXKlZ1nPvvkk09y7DeTnJzsMoGQX1l9Kk+ePKmpU6fme/2irHmyv9+///77OY6bOXNmoes8dz+jGjZs6DzSZurUqUpNTS3wPocMGeL8cm3ixIm67LLLNHv2bJUqVUppaWnq2rVrjrl46jPVHQ0bNnQeIZW9lvPE875KlSrOo24++eSTHG9LamqqPvnkk3xv3xuK8n8Md7j7msyq53Kr5RYtWpTnUZme+D/i6quvdjbFnzVrVo6/tDl+/Ljz/e6yyy7zeq8+MHkF5NsVV1zhPCx00qRJtm+OH3/8ca4fYmXKlHGevebHH39U//79c/0J4sGDBzVt2rQC5Zv1Rnro0KFcmx+2bdvW+dO6V155Jc/ic9u2bVqyZIkRf+qpp5yn7Z06daoqV64sSXr22WfVsmVLSWdOCZ7TN1hZ+ebndMh29uzZo5UrV+Y65ptvvnFezj4pWbduXecpj+fOnatXX3011+3s3bvXmKxs3ry5s6Hpm2++afvNzeHDh9W/f//cb0gR6tmzp2JjYyVJAwYM0KpVq3Id/8MPP+R5HxdU9gIgt+dC7dq1nZdnzpxpO+btt9/WokWLPLK/vNx1113O5/zIkSNdztCVJS4uzvlzi4iICD3wwAMF3h8AuGPIkCGSpKSkJN177725nnU3LS1Nb731ljHx0bdvX0lnfibzzDPP2K7bv3//AjeMlqRu3bo5+0r997//zfUzJj4+3ogVZc1z1113Ofc3YsQI/fHHH8Z6v/76q0aOHJnrtt3h7mdUiRIl9Pzzz0s6Uwf16NEj13/ik5KSNGnSJCO+YsUKTZgwQdKZib6HH35Y0pmfdGV9qbd9+/YczyDtqc9USZo3b16uzbk3btzo/CXEuW0pPPG8f+SRRySdeb7ldHufffZZ/f3333nelqJQlP9juMPduj6rnluyZIntTwN3796txx9/3GP7y01YWJgeeughSWee51lfwGdnWZaeeOIJ54Rp1n0OL7OA84QkS5LVsmVLY1nLli1zXGZn8ODBzu21aNHCWrhwobV582brq6++snr37m2VKFHCatGihXPMjBkzjG2kpqZaTZs2dY6pX7++NWnSJOuHH36wtmzZYi1btsx68803rfbt21uhoaHW1VdfXaDb/e233zr3cf/991tr1661du7c6fzLbteuXdYFF1zgHH/HHXdYs2fPtn766Sdr48aN1pdffmmNHDnSatasmSXJeuaZZ1zW//TTT53rPvDAA0Yuf/75pxUdHW1JsurWrWudPHnSGPPf//7XuY3Ro0dbW7dudeYaHx/v9u1evny5Jcm67LLLrP/+97/WZ599Zq1fv95av369tWDBAuu+++5z7qdBgwZWZmamy/r//vuvVbNmTeeY66+/3po2bZq1du1aa/Pmzda3335rjR8/3rrpppusEiVKWPfcc4+Rw+rVq60SJUpYkqyIiAhryJAh1urVq63169dbkydPtmJjY62QkBCrQYMGliSrevXqxjb27t2b6/Po3NsryVq+fHmO42bMmOEct3fvXmP52rVrrbCwMEuSFRQUZHXt2tX65JNPrI0bN1rr16+3Fi1aZL3wwgtWvXr1LEnWm2++aWwja/vDhg3LMQ/Lyvt1V6VKFUuSVaNGDWvRokXW77//7nwuJCUlWZZlWZmZmdYVV1zh3Od9991nLVmyxNq4caO1cOFC695777UkWddcc02ueSUlJVklS5a0JFkNGza0vvnmG+uPP/5w7i/7c3XYsGHObdn5/PPPLYfDYUmyoqKirJdeeslas2aNtW7dOuvVV1+1Klas6Fx/8uTJttvw1H0IwH9lf9/O67We1/q5ve9nefrpp53jK1WqZL344ovWd999Z23ZssX64YcfrJkzZ1oPPvigVbZsWUuSdfz4cZf1T58+bV111VXObdx8883WwoULrU2bNlkLFy602rZta0myGjVqlGtePXv2tCRZ1apVs81z2bJlVnBwsCXJCg4Oth544AFr0aJF1qZNm6wff/zRmj59unXvvfdaoaGhxrpFWfNYlmXNnz/fuX6ZMmWs0aNHW2vXrrV+/PFHa9SoUVZ0dLQVHR1t1apVq9Dv1e58JlrWmc/FDh06OPO6+OKLrXHjxlkrVqywtmzZYq1cudJ65513rC5duliRkZFWuXLlXPZz9OhRq2rVqpYk68ILL7QOHTpk5JK1fYfDYX333XfG8p07dzr337ZtW2vlypXWjh07nPmePn3a7dtdrVo1q0yZMlbPnj2t9957z1q9erWzDhs2bJjzMQwKCrI2bNhgrF/Y531aWppLnXH77bc7n4+LFi2ybrvtNkuS1aRJE+eYFStWGHm4+3ldrVo1S5LVs2fPXMfl9t7hif8x8nqdZsmrrnS3rn/llVec4+rUqWO999571k8//WStXLnSGjZsmBUdHW2VLFnSatiwYa55de3a1ZJkhYWFWVOmTLG2bdvm3N/Bgwed4/Kqr5OSklz+D7jnnnuszz//3Nq0aZM1f/5864YbbnAua968uZWenu61+xBnMXmF84YnJ6+Sk5OdxYzd3w033GBt3749z0mHpKQk6+67785xO9n/WrVqVaDbnZGRkWuu5/rjjz9cPqRz+xs+fLhzvb///tsqV66cJcmqWbOm8eGfZfbs2c71+/btayyPj493KSaz/+Wn6Mte1Of2d8kll1h79uyx3UZCQoJ13XXXubUdu8k6y7KsmTNnWiEhIbbrBAcHW++++67VvXt3Zy7nKurJK8s6M4EVGxvr1u2eNWuWsX5uBVV2eb3uJk+enON+s98XW7ZscRaddn/16tWz/v777zzzGjhwYI7byH6f5jV5ZVlnHvesSUC7v6CgIGvUqFE5ru+p+xCA/yrqyavMzExr+PDhzomh3P4iIyNtv2Dav3+/Vbdu3RzXa9u2rbV06dJc83LnH7qvv/461/f1nN6Di6rmye6VV15xfmFx7l9ERIT1+eefe+S92t3PRMuyrFOnTll9+/bNMa/sfzVq1HBZt0uXLs5lX3zxhW0uhw8ftmJiYixJ1kUXXWQdOXLEGJP9S8Jz//LzD3rWZE5uf2FhYTnWSJ543v/555/WxRdfnOvz/quvvnJeX7dunbGNopy8sqzC/4/hqYkXd+v6U6dOOSfA7f7Cw8Otjz/+OM+8tmzZkmP9lf0+dae+3rt3r3XJJZfket9dc8011r///mu7PpNXnsfPBoECiIiI0LJlyzRy5EjVq1dP4eHhKl26tBo3bqxJkybpu+++U2RkZJ7biYqK0oIFC7R69Wo99NBDqlu3rqKiohQcHKwLLrhAjRs31uOPP64vv/xS3377bYFyLVGihL755hsNGTJE9evXV6lSpXJtnlinTh1t3bpVc+bM0T333KOqVasqPDxcoaGhiomJ0Q033KAhQ4Zo06ZNeuGFFyRJlmXpgQce0L///qugoCBnTwQ7Xbt2VZcuXSSd+TnXl19+6bL8oosu0vr16/Xggw+qVq1aLn0T8uO6667TihUrNHjwYLVq1Uq1atVSVFSUQkJCdOGFF6pt27aaMmWKtm7dmuPZDytVqqRVq1bp888/V9euXVWzZk1FREQoJCREFSpUUIsWLfTMM89o5cqVmj59uu02evbsqY0bN6pr166qXLmyQkNDddFFF+m+++7TDz/8oIceekhJSUmSpOjo6ALdVk9r1qyZdu7cqSlTpui2225z5l2yZEnFxsaqbdu2GjlypH7//Xf16NHDa3n07dtXCxYsUNu2bVWxYkUFB9ufILdBgwbaunWrHn30UVWrVk0hISG64IIL1KRJE40fP17r1693qw/BmDFj9O677+q6667TBRdcUKCzTGbp2bOnfv/9dz399NO69NJLFRkZqfDwcF188cXq06ePtmzZosGDBxd4+wCQXw6HQy+88IJ27NihgQMHqlGjRs73uqioKF122WXq2rWrZs2apYSEBNumyZUrV9aWLVv08ssv64orrlB4eLjKlCmjZs2aafLkyfrqq68UGhpa6FzbtWunPXv2aNSoUWrRooXKlSunoKAglS5dWg0bNlS/fv1cGiVnKYqa51wDBgzQDz/8oLvvvlsVK1ZUWFiYqlWrpt69e2vjxo267bbbCn1/SO5/JkpSSEiIJk+erJ9//llPPvmk6tWrp+joaAUFBSk6OloNGjTQgw8+qPnz5+u3335zrjdnzhxnG4S+ffvq1ltvtd1++fLlNWPGDDkcDu3fv1+PPvqoMWb27NkaN26cmjRpoujoaJezdefH8uXL9frrr+uee+5RvXr1VKFCBQUHB6t06dK66qqrNGDAAP3666/q1auX7fqeeN5XrVpVP//8s4YPH57j8z77zw39oZ4riv8x3OFuXR8SEqIvvvhCb7zxhho1aqSIiAiFh4erVq1aevTRR7V582ZnS4/cNGjQQGvXrlWXLl1UtWpVhYWFFTj36tWr6+eff9akSZPUsmVLlStXzvl/xM0336wPPvhAq1at4iyDRchhWT7u4gYA57latWpp9+7d6tatW67N3QEAAOB/Xn75ZQ0dOlTBwcE6fvx4gb98BZAzjrwCAB/asGGDs6lk1llxAAAAEBgsy9K8efMknTnyh4krwDuYvAIAL9q1a1eOy/7991/16dNH0pkzm3Tq1Kmo0gIAAIAb9u3bp/T09ByXv/DCC9q+fbukM20DAHhHzj+WBgAUWps2bVSjRg116NBBV155paKjo3X06FGtWbNGkydPVkJCgqQzp3MuX768j7MFAABAdjNnztSMGTN0//3365prrlHlypV1+vRp/fbbb5o1a5ZWrFghSbrsssucX0oC8DwmrwDAiyzL0vLly7V8+fIcxzz22GN6/vnnizArAAAAuOuvv/7SmDFjclx+ySWX6IsvvihUg3AAuaNhOwB40cqVK7VkyRKtWrVKCQkJOnz4sIKDg1WpUiVde+21evjhh9WiRQtfpwkAAAAbcXFxmj9/vr755hvt2rVLhw8f1smTJ3XBBReofv366tChg3r37u2RM20CyBmTVwAAAAAAAPBbNGwHAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJq/+3YcMG3XrrrSpTpowiIyPVrFkzffzxx75OCwAAwG9RPwEAgKIQ7OsE/MHy5cvVrl07lSxZUp07d1ZUVJQWLFigTp06KS4uTs8884zH9pWamqpt27ZJkipUqKDgYB4CAAD8UXp6ug4fPixJqlevnkqWLOnjjPwL9RMAADiXt+onh2VZlke2FKDS09N1ySWXKD4+XuvWrVODBg0kSYmJiWrSpIn27dunHTt2qFq1ah7Z34YNG9SkSROPbAsAABSN9evXq3Hjxr5Ow29QPwEAgLx4sn467382uGzZMu3evVv333+/s/CSpOjoaD3//PM6deqUZs2a5bsEAQAA/Az1EwAAKErn/THXK1askCS1bdvWWNauXTtJ0sqVK93eXnx8fK7L09PTnZenLrhKdWqecl5PHGl+o3j8WJQRu+T1J9zOxx0ZXz5oxIJufc+tdbc/NsV5OTE4ROPqXCpJWvREC11YOtwzCcJnvm8z1Yjd+O3DPsgEAIpeQkKC82ifChUq+Dgb/0L95Ln6KcsVkx91Xv73RJp6z9wkiZoqEFE/ATifeat+Ou8nr3bu3ClJql27trGsUqVKKlWqlHOMO2JjY90eW6fmKdW/9KTz+r/hIcaYYyfM34defZmZa2GkbzptxILd3MfpoLPF1L/BoQouXV6SVPmiKoqJptAKdOVDyhixKlWqFH0iAOBj9FhyRf3kufopS/b8EhJTFFz6T0nUVIGI+gkAzvBk/XTe/2wwMTFR0pnD3O2ULl3aOQYAAADUTwAAoGjxNaKHxcXF5bo8+yF0iSObuHxbWO7db43xe641DzGeHjPdiPVO6J3fVJ2Wv9HeiLXp7t66R/4p67x8rCRPp+Lm0D/2/5QAAOBJ53P9hOKH+gkAPO+8n23I+sYwp28Hk5KSVLas+wUGhwQDAIDijvoJAAAUpfP+Z4NZvRrs+jIcOHBAJ06csO3nAAAAcL6ifgIAAEXpvJ+8atmypSTpm2++MZYtXbrUZQwAAAConwAAQNE67yevbrzxRtWsWVNz5szR1q1bnfHExESNGjVKoaGh6tGjh+8SBAAA8DPUTwAAoCid9z2vgoODNW3aNLVr107XX3+9OnfurKioKC1YsEB//vmnxo8fr+rVq3tl38ePRbmcytmuuWjjH6YasRLXP+TRPA4fLlPgdRtcv8V5+ZAjXFKtwicEv/HA3w/6OoV8m13VfM10+8t8bRXGqLCPXK4/n9alwNsqinyLwlcNxhuxW7YOcGvdxVe8ZsTu3N6vkBkFvk/rvmnELih3zIjd8ONQt7Y3pfwsI/boPz3znRcgUT9JnqufUPxQP9mjfjJRP3ke9VPxdd5PXklSq1at9MMPP2jYsGGaN2+eTp8+rXr16mns2LHq1KmTr9MDAADwO9RPAACgqDB59f+aNGmir776ytdpAAAABAzqJwAAUBTO+55XAAAAAAAA8F9MXgEAAAAAAMBvOSzLsnydxPkkPj5esbGxkqSN/9uhqy+r7Vw2PWa6Mb5a1QNG7OpV04xYmbA9bu3/pZC5RizIYT4Fvss8acQeq5FqxH7ZU855ObmUQ5/2LSVJWju4tWKiw93KKS92Ob9wunOBtzc0yNxemZIZRuyZ5K5G7JPabxmxjjsfN2J3l/jAiH2a2d3dFA1vljG39+Qx97Znd3tHZBT8/vOV/o55Rmyi5ZueKitajHC5vu3X6sYYdx8fO/7UhLS4PH/stAmeYcS+TX/Ao/sYVMJ83o7NdO95OyHyQyNm975k99nRO6G3W/uw40/PP1/L/pkdFxenKlWq+Dij81dxrp+yZH9vTUhMUfPRyyQVvKaifqJ+kqifqJ88j/rJnj89/3zNW/UTR14BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fs0bC9iuTUcLYxjaTXN4MgrjdDOny41Yo2XjvZIDp5oLgp4w/dNRxmxG3963geZuGffgw8aservveeDTIDzGw3b/Udxrp/sUFPBH1A/ASgIGrYDAAAAAADgvMPkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8F+zoBeIhNc1H99xcj1DhsofdzAfxMeESqr1PIF5qLet7vnZ40YpfMe9Pr+910yyAjdvVXY72+3+JsW4f+RqzeZxN9kAmKBeonIEfUT6B+Kj6KQ/3EkVcAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BYN2wPQSyFzjdgtrS81YnbNRY+l1TRiZcL2uLXf1dcPN2LXrRrm1rrTY6Ybsd4Jvd1a11eKoqnd11e9YsRu3vKsR/fhaYH4WLZY/pKvU8jRzIumGbFe+x/yQSbFW1E0F7VDc1HPC7TmovAfgVg/SdK8hvNU+mSm87q/f+ZSP9mjfvIs6qeiQf1UfBSH+okjrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LRq2+1DGlw8qfdNp5/Xlb7Q3xhw+XMaIBTmijVjjpaPd2qddc1G7JqS/3tzNiF23ymza+Ev7Z5yX/wkOk2pfY7tff2pIadfgsXSpFCN29x/uNbVb0WKEEVu6ro4RG53ZyYi521x0d89HjNjFs95xa93CGBX2kRF7Ps18LL9qMN6I3bJ1gFv7WHfjECPW7PuXjdjkC943Yo8d6eHWPgpjSNA8I/ZyhutjufiK14wxd27v59b27ZqL2j2nbvhxqBH7tvEYI9Zmw3NG7NO6ZrPNu/940q38PK0wzxX4F7vn6Tc2732jbN77Roaa7y21qx41YvfteqyA2dHMtzgrbvVTlisXTbDdd6fNnRQTHe5Oml5F/eQ+6ifqJ0+jfio+qJ8KjiOvAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtGrb7UNCt7yn4strO6226u7deq+D3jNh/C5GHXXPRy76ebTPSbDj62uJGzsupUQ6ptjGkyEwqazakfOKo2ZBy1d+RRqysoozY3W7ud+NWs2FrsMNyc233/L6lrhG72M11ezvMxn7TrS5GLKqk2bT2eNpgt/axbnsVI3aLzbhnHGbzzloXmE+aZjbrLj9mzrW724rwrqAPjNjCDPdecN+WOGbE1gZPd7neJDPGGHOne6nZsntO3WAzbv3P1YxYG5txJUpkurXfhx1zjdhUq7Nb67rL7rmyqoT5vLBr0OtPBruZc1fHHCP2oXW/V3IqanZNcJ8NMRshj7JZ97vMk0bsv4VoLmrH7r2+l0f3AF8pbvVTlulGpGhQP9mjfqJ+on7yPOon6qfC4MgrAAAAAAAA+C0mrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH7LYVmWZzsjIlfx8fGKjY2VJG383w5dfVn+O5x/UvstI9Zx5+Nurbv6+uFG7LpVw9xa91ia2QSxTNge5+WExBQ1H71MkrR2cGvFRIe7tV1/sPHm54xYo6/HuLXuzq59jVjKiQgjduWiCflPLBe/3PUfcx8LX/XoPoqzj2tNNmL3ebjhIVCc2b331f7wbR9k4j3ZP7Pj4uJUpYrZMBdFozjXT3YCpaaifjr/UD8BhUP9VHAceQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbwX7OoHz2fbHpuh00NkGnEf+KWuMaXD9FiP2y57bjVhHN/dp11z0l/bPGLHXFjcyYtMts7lo9iakSWllJI1wMxP/4m5z0XHhc4zYVVdUM2JfbqxhxCbmPy2nBXUmGbF7dhSP5qLuNsGdGPWhEet/vGuB9+tuc9EBjnlGLDLI9TwXV9b8xxhzz44nCpaYpG8bm8/HNhvMprhf1jeb2J5ODzJiKSkljVjnPY8WMLvCWXT5a0as/f/6FXkegcrd50ZRsGsu+ozN62WC1cmIDQ2aa8RGZHT2TGL/b2qFmUbs4cO9PLoP+EZxq5+y5NXE3R9RP/kO9ZOJ+gk5oX5ynz/XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fv0vPKhxOAQ/Rsc6rx+rKT5cBxyhBux5FIOI5aQmFLgPP4JDjNiqVHu7eNMn6szDh8v7bx8KCm1wPn4Qky0eT8DAAAAAADfc1iWZeU9DJ4SHx+v2NhYSdJFfWcquHR5H2cESdo35jZfp+ARS68eZ8TabRrog0yKj6fsGo6eM7c7OtNsqDin+hQjdv8+3zT5BFAw2T+z4+LiVKVKFR9ndP7K/lhs/N8OXX1ZbR9n5HnZm7gfTCyjdq+eOQnO2sGt8/ySbW5N8zPHV42lAxH1k+dRPwHnL2/VT/xsEJBU/bkvCnX0GgAAAAAA8A5+NuhDi55oocoXFZ9vcQ8lpar9Wz9Kkmb3eUUVopKcy0qHrXFrG4tbzDZid/7YzTMJ2sieMwAAAAAA8D9MXvnQhaXDi22vpQpRSbow+pjzepkw925ndEqGESuu9xEAAAAAAMgbk1cAAAAIGP+eSCuWP/UvzElwEsODjJin7yO+TAQA+BIN24uYr5u/To+ZbsR6J/T2yLYTElPUfPQySWZz0exNSLP8dV8HI7br9+pGrEnrjUbsh6XNze0llDZiDz79mRHb9/PZXP4NCdXDlzWzzdnOuPA5Rmxgyv25roPcjY/40IgNONnVB5kAgCtff2bjLE5443sLfl5lxK7+aqxb61I/eR71EwB/RcN2AAAAAD5xT/3r9W9IqK/TAACcp/jZIAAAAAKGL054M6/hPCPWaXMnr+0vt5Pg7O97szF+3y7z/mhwzS9GbMPKq43Y/kOljFjnB792Xv5H4eqhO9xLHAAAL2HyCgAAAAHDFye8KX0y04gVVQ7nngQnLT3NGHMs1TzhTUXL7Hlld2KcxBNmB5ELdTKfWQIA4F38bBAAAAAAAAB+iyOvzjOeas6eX3bN2at+bDZT/zB8tBFr2+uwEQsNOW3Enn7tHSN2eEsNI7btl9rOy4kRJaTLzHxzQnNRzzufmot684QJAADv8eV79f6+N7scbVXU9VOqI1yKPnP5t99qKDrbUWjmjxDtUT95HvUT9RNwvuHIKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+i4bt8IrFLWa7nI45NKS6McauuejglMFGbFhJc1y7q/cZsTnDexixnxIijVioHM7LKVEOYznOD3cEvW/ElmSYzyE7d5f4wOX61cHuvZX+9xTNRQNRL8dHRqx2iDlu32nz/eRdq7M3UgJQDM2tOcV5OTE8SLqjsiRp364qOpZ6tqYq6vopNcohPXbm8vaDpRR+3HIu62XeDBRz1E9wF/UTPI0jrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LRq2B6CXQuYasRdO+1dTuzt/7KaY6HDn9fi+PY0xbXsdNmJ2zUWHpppNSL+94hkjdu/jnxmx9imhRmzhe7c7LydFlNC3Mpu658f3TUcZsRt/er5Q2/QXI2yea0P97Ll2rpkXTTNivfY/ZMTcbS5q59PM7gVe1xc+qf2WEeu483EfZOJf+jrM5/fbNg1CZ1pdiiIdAF7m7/VT5z2POi8nJKZo9OhlkqQG1/yiilaKc1lR108HrQityDjzPnh5hZMqHZmZ281wG/WTf6F+MlE/2aN+gq9w5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv+WwLMvydRLnk/j4eMXGxkqS4uLiVKVKFR9n5DkJiSlq/v/NRdcObu3SsH1uzSnG+NCQ00asVNRJI5aYWMqItdk+wYhZL9c3Yp/PvNWIdY/r41bOACBJ71acYcT6HHrAB5mgqBXnz+xAc749Ftnrk8FL/lZ0SoZzWVHXT4nhJTT+7kqSqJUAuI/66fzlrc9sjrwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4LeCfZ0A/NOksu8bsSeO9ijw9v5KKG3Enn7tHSM2Z7i5j3sf/8yIpds0F3UM+dmI3WY5bLLpYxNDUZhaYaYRe/hwryLPA8gPu+ai02OmG7HeCb2N2IiQuUZs6OnOnkmsCE2I/NCIPZPc1QeZAP7N0/WTJO0/VEqJJ86eX6mo66eDVoTGZ3RxO194HvUTAhH1E/WTp3HkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/RcN22Cpsc9FzPfi02TT08JYaRuynhEgj1j4l1Ih9MesWI2bXnL3E0K1GLHsz1eORJaRuZY0x8A6ai/q3t8vNMmJ9/+3p9f3OqT7FiKWdCjFiD/z9oNdzcZddc1E7gdhc1E5EyXRfpwAEBE/XT5LU+cGvdaFOOq8Xdf1UIrGM9OqZyzMvX6Co5EznMm/cXpion/wb9ZP7qJ9QGBx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fv0vAIAAAD81D8Kd7me6gg3xqRGmX2rDloRRiwx3Pze2m5cicQyzsuHj5d2Xj4R4VD2774TElNscw4kMdHm/QkA8D9MXgWgoUFzjdiIjII3tZt50TQjtupvs/HndKtLgfex7+eaRmzbL7WNWKjM4mvhe7cbMftmf32MSPbm7Fm6HXjReflgYhm98+oISdLiFrMVnZLhXNZ5z6M2+3BPf8c8IzbR6lTg7S2oM8mI3bPjiQJvD7BTFM1F7YSFms0sMzM5MNjTXo+ebcSeTuzm1rq+em4MCTLfS1/OKPh7Kc5vgVg/SVIP3eEaiLYZ9JgZWpFhs9+7zdB4u3Gv2ufy4d1lXK6/M3qZ/cAAsm/Mbb5OAQGO+ql4o37yHzy7AQAAAD8SEx3OpEoRqf7cF8XiCDIAKO6K1ZFX+/fv1yeffKIvv/xSv//+uw4cOKALLrhA11xzjQYOHKimTZsa6yQlJenFF1/UggULdODAAcXExKhjx44aNmyYSpUq5YNbAQAAUHSon/zX1F/XGbHffqthxLYfNO/zyyucNGKdNrv3zfvMyxc4L5+IcDiPuJrd5xVViEpyLlvRqq+x7p0/undEgp3hsUuM2LC4O2xGuufL62casVtX9ZIkHUpKVfu3fizwtgEARatYTV69+eabGjt2rC6++GK1bdtWFSpU0M6dO7Vw4UItXLhQc+bMUadOZz+0k5OT1bJlS23dulVt27ZVly5dtGXLFo0fP14rV67UqlWrVLJkSR/eIgAAAO+ifvJf5U6fMmLRJzONWPhxy4iVjjTHudvfKSo5+7pnf6hRISpJF0YfO5tLtnYL+d2HHbvbUZjtlfFwfgAA3ylWk1dNmjTRihUr1LJlS5f46tWrdeONN6pv37666667FBYWJkkaN26ctm7dqkGDBmnMmDHO8c8995zGjh2riRMnavDgwUV6G4qLQ0mpLtf/DQk1xiRGmL9aTbFpOJpkM87dw7uPR9o0Js2hCWlSSdexhTmE3O52FGZ7x8KD3NoeBRkAIL+onwAAgL9zWJZlfsVRDLVr107ffPONNmzYoEaNGsmyLFWpUkVJSUk6cOCAIiPPNthMTk5WpUqVVLFiRe3evdujecTHxys2NlaSFBcXpypVquR7GxMiPzRizyR3LXBOn9Z904it2VHRiHVpt8WINfr6bNGakJii5sWgcWcgoz8GAF8aEWI2xB56uuANsX3NE5/ZgY76KWeeqp/8Xfb6bvCSv12Otrr5t3HG+DJhe9za7o+tXjBiVS/504hVeXuWu6kall5t5hccfKbJ9ZGwED3b4jJJ0trBrfkCEIDPUD+5p1gdeZWbkJAQSVJw8JmbvHPnTv39999q166dS+ElSZGRkbrmmmu0dOlSxcXFOe94d8THx+e6PCEhIZ+ZB46s5qLVn/vC16mct6o/9wUFGADAY6ifAACAPzgvJq/++usvfffdd4qJiVG9evUknSm+JKl27dq269SuXVtLly7Vzp0781V85WdscbV2cGtfp5CrxS3Onu40qWQJvdWmkiSzCWnpsDVubW/jfROM2EUXm0V4zOiJ+U3VaeUtbxuxoOCz33weCw3WyEZ1Crx9AADORf0EAAD8RbGfvDp9+rS6d++utLQ0jR07VkFBZ3oHJSYmSpKio6Nt1ytdurTLOLjP34/6sWsuKplNSMuEuXc7yp0ym6lWtDzbj6psWroRC84wYwAAeAL1EwAA8CfFevIqMzNTvXr10qpVq9SnTx91797d6/uMi4vLdXlCQoKaNGni9TwAAAAKgvoJAAD4m2I7eZWZmanevXtrzpw56tatm6ZMmeKyPOsbw5y+GUxKSnIZ566iaOZamOai2zr0N2J3/2H+nO1u27U72UYDTec9jzovJySmaPT/NyEtHbbG5WirY2k1jXXtmpC2WP6SEUt86U63ckn/oLkRC+6+1oi12zQw1+0kJKZINMsH4GOB3FwUZ1A/2aN+OuPOH7udcyT5o8aYQKmfqJ0A+AvqJ/cUy8mrzMxMPfDAA3r//ffVpUsXzZw5UyVKlHAZk9WrIat3w7ny6ukAAABQnFA/AQAAf1Ui7yGBJXvh1alTJ33wwQfOPg3Z1a5dW5UrV9aaNWuUnJzssiw5OVlr1qxRjRo1aCAKAACKPeonAADgz4rV5FXWoe7vv/++OnbsqNmzZ9sWXpLkcDj00EMP6cSJExoxYoTLshEjRujEiRPq06dPUaQNAADgM9RPAADA3xWrnw2+9NJLmjVrlkqVKqU6dero5ZdfNsbcddddatCggSRp4MCBWrRokcaOHastW7aoYcOG2rx5s7755hs1btxY/fr1K9obAAAAUMSonwAAgL8rVpNX+/btkySdOHFCI0eOtB1TvXp1Z/EVGRmplStX6sUXX9SCBQu0fPlyxcTE6JlnntGwYcMUHh5uuw1f+6T2W0as487H3Vq33mdmc9HCGBc+x4gNTLm/wOP8iV1zUbsmpJnDrzJi/xndxYjNfMHch11zUU8LxPvezrDguUZseLpvmhuuu3GIy/Vm35v/6Hna69GzjdjTid28vl8AxR/1U96on9xH/eRfqJ+on4DiolhNXs2cOVMzZ87M1zrR0dGaOHGiJk70bFECAAAQCKifAACAvytWPa8AAAAAAABQvDB5BQAAAAAAAL/F5BUAAAAAAAD8VrHqeXW+cLe5qLtWtBhhxDZuNRtrtu/wgxG76opqbu2jMA0uv286yojd+NPzBd5eTjbeN0HlTp1yXm+x/CVjjF1z0RLDthixJzbXttmD2YTUXT+1+a8RCw5Od17+NyRUuqyZ7br+3lx0V7dHjVit2VOM2NWXHCiKdAzTKs0wYg8dcG0wavf4NP3WvumxO3699ykj9nTiG0bsl/bPGLErF00wYj+2Mrvd2j2/7XzbeIwRa7PhObfWtbPplkFG7OqvxhZ4e/Av71Y0Xy99Dj1gxGZXnWrEuv31sEdz8fRzF4GP+snz9ZO7ny/+WD/lVjtJ1E+FRf1E/QT3UT+5hyOvAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgth2VZlq+TOJ/Ex8crNjZWkhQXF6cqVarkext3l/jAiH2a2b3AOQ0uMc+IBTvMp0XH2zcYsRmLmxixiVanAudSFPo7zt7elCiHvn4sUpL0adISVbRSnMuiYo4a6z49zGwa+kS7n41YrUUfG7EyYXuM2N4H+hixGjPeNWKjS35kxK5tssN5+UhoiJ5uVF+StHZwa8VEhxvj4Tn3lJjtcn1BZjcfZYJA1N0xx4h9YPl3Y+CBDvNzYpzNe33bYLPh6DfpZsPRQOGJz2x4BvWT7yQkpqj56GWSpJsnJyv8+Nnb+MyjXxrjA6V+onYqetRPKAzqp8DhrfqJI68AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+i8krAAAAAAAA+C0athcxmr/6l+xNSL3drPNYWk0jZteEtCCK8nb4kxUtRhixG34c6oNMUBi7ez5ixC6e9Y4PMgFc8ZntP3gsfMfXNYa36idf3y5fon4qHqif4K9o2A4AAAAAAIDzDpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAvxXs6wRQtL6+6hUjdvOWZ32Qif9L/6C5EQvuvtatdfc+0MeI1ZhhNhf1ZhP34uaPLo8bsRt+fMsHmcDTaC4KwN9RP7mP+sm/UD8VX9RPON9w5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv0XD9vMMzUXd525zUTs1Zrzr1ji75qI0IbVX9yOaiwIAfIP6yX3UT/6F+glAccGRVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8Fg3bA9CbZT4wYk8e617g7e3u+YgR+31LXSN22y//MWIL6kwyYvfseKLAuRSF7DkfCw+SbqkqSVp5y9sqm5buXNZu00C3tvdTm/8asWWrrzBig1O7uLW9860J6c93DjBif+6pYsQSEyON2PHkMCP22JEenkns/40Ln2PEBqbc73L9uyajjTE3rR9sxD6uNdmI3bfrMSNm95xq+u1II/ZDyxeN2LUrzdjSq8cZsd17KxkxT993dla0GGHEbvhxqNf3a2dI0Dwj9nJGJx9kYs/ucXP3fclXxpY0Xy+DUu83Yp7+HLMTiJ9P8C7qp8L78vqZKpOS4bxeKuqkMYb6qWhQP1E/UT/Zo34qHH/+fOLIKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+y2FZluXrJM4n8fHxio2NlSTFxcWpShWzsaK/+uUus+HolQtf9UEmnpOQmKLmo5dJkl758VddkHbauezGn553axubbhlkxE4mRxix61YNK2CW9rI3IT2YWEbtXj3TyHHt4NaKiQ736L6K2lcNxhuxW7aajUmLwmulZxuxfkndPLb9JfUmGrE7tvX32PYBFFwgf2YXN4H8WAR6/ZS9Vjq3xvi+6ShjfKDUT8WtdpKon6ifAP/grc9sjrwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4rWBfJwD4i2Ohri+HhMQUt9b7NyTUiKWEhhgxd7fnrqS0Ms7Lh4+Xdl4+lJTq0f0UteLQcwIAgOLo3BrjSFjB6x1f10/FqXaSqJ8AFH80bC9igdxw1F1Lrx5nxNptGuiDTPKWvQkp/EOncSc0NrOTW2Mfd8w1Ym9ZnT2dUp6mVphpxB4+3KvI8/CGUWEfGbHn07r4IBOg6J0Pn9mB4nx4LPy1fqJWCgzUT/6F+gnnMxq2A14QEx2ufWNu83UayGbewFIe/5YVAAAUDLVSYKB+AlDc8bNBQGdOkRzIDiWlqv1bP0qSZvd5RRWikpzLtnU0v0m7ZvGTRmxxC/OUxnf+aJ7SeM2db7q1vaGxS4zYiLg7jNio/x+XEunQdz3NU2QDAADfC/Ra6Vy51U4S9RMA+BsmrwAVrz4BFaKSdGH0Mef1/WmnjTF2tzc6JcOtcRe4ub3w4+Yvku3GRZzgl8sAAPi74lQrnevc2kmifgIAf8PPBgEAAAAAAOC3OPIqAA0NMpssjsjwbJPF3g6zyeB0y70mg/7QXNRbxoXPMWIDU+73QSY529axs8u3hQ1XvmeMWd822YjVqpNpbqtDfyO2a3d9I2b3Q4L2jffkkekZFUqmS5JOlHTkOm5i1IdG7C2rq1v78LRhwa6vweHpvXySR1Gway5anBusAii+qJ98x9/rp3NrJ4n6yRuon2YaMeonwH0ceQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAb9GwPQB5urmoHXebi55v/Km5aE6uWfykyymV7ZqL1lliNq3tHT7ciE18cLkRc7ex5A+baxixm2zGDTh5pmloQmKKZo5eluP2+h/3TXNRO8PTvf8a9GfFpbmou42Vx5Y0Gw0PSnXvveD16NlG7OnEbm6tC2lwiXlGbHRmJx9kguKA+sl3/L1+Ord2kqifvIH6qZevU/AI6if/V1zrJ468AgAAAAAAgN9i8goAAAAAAAB+i8krAAAAAAAA+C0mrwAAAAAAAOC3aNgOW1ElRxux46mDfZAJ8mtxi9mKTslwXq9VJ9MYY9dcdHrKMCPWrtQgI/ZW3HNGrNHXY4xYkCPPVCVJP985QJL0T3CYVKeFJKl/7EKFHbdcxh0sccpYt5mjpBHbkZlhxA6WSDNiRx1mbPPpvm7l3DTkHZfrP51+xK314F8Wh8a5Nc7d5qJ2iqK5aHFtyikVn9uB8wf1U2A6t3aSqJ/OrEv9BBP1k/8rLrfjXBx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0bDdh75vM1XlQ8o4rx/6J9oY88DfD3o9j1FhHxmx42n+01x0RMhcIzb0dGcfZBIY7vyxm2Kiw53Xt3Xob4yZ+OByI2bXXHTpibFGrEzYHrfyiEt3a5jqLx4vSUpITJFGLzuTX9xdLrchP+yeL3NO9y7QtnLiyQaj/vT89qdcxoXPMWIDUwre+NNOo/SKHt2erxRFU053nxsdS8w2Yp9ker/p6sMOM7+pVsGfu70cZz4Xk/VvgbcB76F+co8/vaf7u3NrJ4n6SaJ+cpc/5UL95D7qp8CrnzjyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4Lf8YvIqMzPT1ykAAAAEFOonAABwvnBYlmV5a+OPP/64Xn31VYWFheU4Zt++feratavWrFnjrTT8Snx8vGJjYyVJcXFxqlKlSpHuf3rMdCPWO8GzzRhR9BISU9T8/5t1jl/7P12Qdtq5bNfui4zxDx/uZcQ23vycEWv09RgjdiytphGza0LqboPC1dcPlyQdCQ3R043qS5LWDm5d4IajQHExt+YUI9Z5z6M+yMR9zzjmGbEJlvcbonqLrz6zqZ9M1E/wtNxqJ4n6CQhU1E++563PbK8eefX222+rcePG+t///me7fO7cubrqqqv0008/eTMNAACAgEH9BAAA4Mqrk1ejRo3SH3/8ocaNG+utt95yxpOTk9WrVy917dpV4eHh+vrrr72ZBgAAQMCgfgIAAHDl1cmr5557TqtXr1blypX11FNP6c4779TSpUt11VVX6f3339dtt92mX375RTfddJM30wAAAAgY1E8AAACuvN6wvUmTJtq6dau6du2qzz//XLfeeqv279+vSZMmafHixSpfvry3UwAAAAgo1E8AAABnBRfFTo4fP674+HhJkmVZCgoKUkRERFHsGueway76VYPxRmzddrOp2vB0s1kk/M81i590adbZ2s317JqL2rFrLmrXhHToaXOcnetWDZN0pnGq/r9xKgD/by5qJ5Cbi/oj6if/Qf1UvJ1bO0nUT0Cgon4qvrx+5NXixYt15ZVXasWKFXr00Ue1dOlSlS1bVg8++KC6dOmipKQkb6cAAAAQUKifAAAAzvLq5NVjjz2mDh06SJIWLlyoyZMnq02bNvrll190zz33aN68eapfv/55c5pnAACAvFA/AQAAuPLq5NWUKVPUqlUr/fzzz7rzzjud8ejoaH388cd69913dfjwYbVq1cqbaQAAAAQM6icAAABXXp28Gj16tL799ltVrlzZdvmDDz6ozZs368orr/RmGgAAAAGD+gkAAMCVVxu2Dxo0KM8xderU0dq1a72ZBvJwy9YBZswHecAzhsYuUfhxy3m9fWOz8ecPm2sYsSCHua24dDMWa/OuYddc1K4JqV2z0uJgSvlZRuzRf3oWeHvzLn7biP35d7QRG5hyf4H3URgjQuYasaGnvd+QeGLUh0as//GuBd7ebUHm4/ZFRsEfN8BTqJ8CA/VT8XFu7SRRPxUF6ifqJyA/iuRsgwcOHNCnn36q33//XSdPntS0adMkSYcPH9bevXtVr149hYSEFEUqAAAAAYH6CQAA4AyvT15NnjxZzzzzjNLS0iRJDofDWXwdOnRIzZs315QpU9SnTx9vpwIAABAQqJ8AAADO8mrPqyVLluiJJ55QvXr1tHjxYvXt29dl+eWXX64rr7xSCxcu9GYaAAAAAYP6CQAAwJVXj7x65ZVXVLVqVS1fvlyRkZHatGmTMaZevXpavXq1N9MAAAAIGNRPAAAArrw6ebV161Z1795dkZGROY656KKLdPDgQW+mgQJ4xjHPiE2wOvkgE/dNrTDTiD18uFeR5+FrI+LuUEx0eK5jbiqCPOyai9o1If0kdqgkKSmihNS5vNfz8obCNBe102l337wH+ZBdc9Hvm44yYjf+9LxH91uY5qJ2aC4Kf0X9FLionwKTO7WTRP3kadRP1E9Afnj1Z4OZmZl5NhI9dOiQwsLCvJkGAABAwKB+AgAAcOXVyau6devmekh7enq6Vq1apXr16nkzDQAAgIBB/QQAAODKq5NXXbt21ZYtWzR8+HBjWUZGhgYMGKA9e/aoR48e3kwDAAAgYFA/AQAAuPJqz6snn3xSS5Ys0UsvvaQPP/xQJUuWlCTdd9992rhxo/bt26e2bdvqwQcf9GYaAAAAAYP6CQAAwJVXJ69CQkK0dOlSDR8+XFOmTNHRo0clSfPnz1fp0qU1aNAgDR8+XA6Hw5tpIA/rbhxixGpdUNutdVdfb34rfN2qYUZsfMSHRmzASc82D/RVc9Fd3R41YrVmT/HoPn6+c4ARq794vO3YUbFLFHHCcl6vUDLdGGN337u7D3cfcztZzUWz6xg3QpJ0MLGM3nx1RI7rftNorBFru3GQW/stjDnVzcfy/n2uj3l+Hh93uPuc+r3Tk0bsknlvGrHNtw40Yg2/HFfA7Oy521x0+939jNgVn77m0VzgOx9We8eIdf3zESO2oM4kI3bPjic8mkth3qt8jfopMFA/FY4/1U/n1k4S9VNhUT+5h/oJEvWTu7w6eSVJoaGhGjlypF5++WX98ccfOnLkiEqXLq1LL71UQUFB3t49AABAwKF+AgAAOMurPa+yczgcuuSSS9SiRQtdccUVRVp4jR07Vg6HQw6HQ+vWrTOWJyUl6T//+Y+qVaumsLAwVa9eXc8++6xOnDhRZDkCAACci/oJAACgCCevfGX79u0aNmyYIiMjbZcnJyerZcuWmjhxoi655BL1799fdevW1fjx49W6dWulpqYWccYAAAC+Rf0EAAD8iUd/NlizZs0CredwOLR7925PpiJJOn36tHr27KkGDRqodu3amj17tjFm3Lhx2rp1qwYNGqQxY8Y4488995zGjh2riRMnavDgwR7PDfCWlEjXHignSpo9URISU4zYP8Fhbo07Ehri1jg7SRHmfPnBxDKSpMPHSztjh5LMf3qOhplvV+7utzASw82jHIpivwDOH9RPgG+dWztJ1E+FRf0EwNMclmVZeQ9zT/Xq1Y3moadOnVJCQoIkKTg4WOXKldO///6r9PQzTRBjYmIUGhqqvXv3eioNpxdffFFjxozR5s2bNW7cOM2aNUtr165Vs2bNJEmWZalKlSpKSkrSgQMHXL5dTE5OVqVKlVSxYkWPFobx8fGKjY2VJMXFxalKlSoe2zaKr8VXvGbEQoLPNhI9Ghas51u51yQWnrdvzG0FXndbh/5GrN5nEwuTTrH1ca3JRuy+XY8VeHtPOeYZsTesTgXeXnE2u+pUI9btr4d9kIm9ceFzjNjAlPvdWteuqfDev6MlSYnWv3ol/UxjX29+ZlM/5Y36CQWRW/1E7eR71E9Fg/rJd6ifPPuZ7dGfDe7bt0979+51/m3ZskUxMTG6/vrrtXr1aqWmpiohIUGpqalatWqVrr/+elWuXFlbt271ZBqSpM2bN2vkyJEaNmyYLrvsMtsxO3fu1N9//61rrrnGOCw+MjJS11xzjfbs2aO4uDi39xsfH5/rX1YhCnhS2bR0vf31b75O47xV/bkv+DYRQIFRP1E/oehRO/ke9ROA/PDq2QYHDRqk1NRU/fTTTy4NRkuUKKFrr71W3333nerXr69BgwZpyhTPnRo3LS1NPXr0UIMGDTRwoHmK0yw7d+6UJNWubf+tS+3atbV06VLt3LnT+W1fXtwdB3jD2sGtC7xu/9iFRmxi3F0FTyafDiWlqv1bP0qSZvd5RRWiklyWZ0683FgnKMw8jfX+/1UzYrFX7TJiSfHljVjMaPMbu/iB5mmcU4+HS5KOBIXp6YtaGMsBoDCon4CiM2r5TrX6xjwlvbuon6ifABQNr05eLVq0SL169crxzDjBwcG6/fbb9f7773u0+HrhhRe0c+dObdq0Kdez8iQmJkqSoqOjbZeXLl3aZRzg72Kiwwu8bthx8xfEhdleYVSIStKF0cdcYpmOk8a4IMdpI5aWnmbEKpVINmIlLbMJsd3tPZVpfiOYklHsz3UBwIeon4CiUzYtnfpJ1E8A/J9XJ6+SkpLyLFwSExM9WtysXbtW48eP14svvqgrrrjCY9t1V16HyCckJKhJkyZFlA0AAAg01E8m6icAAM5vXp28uvzyyzV37lwNGDBAF198sbF8586dmjt3rseKpPT0dPXs2VNXXnmlnnvuuTzHZ31jmFPxl5SU5DLOHUXRQLS/TZO8iYVokjf5gveN2PJj5jcjn2R2M/cb9aER63+8a4Fz8XfDgucasasvOWDE7tzez63t/dHlcSNW96O3jFhiovktV/e4Pm7tw93H6GCJU25tz9O+aTRW0v+fDee6SySdOcT93G8KSwzbYqxrjbzSiK1Y3tCIVa4bb8RO2tynu3uaPxsICTO/Ub2wzv9vz4qQ/v/I+wWN5yg6JdM5xt3Hxy7fvTYNZu2eUwvqTDJi9+x4wohNj5luxHon9HYrP0+za+54/75H3Vq3MM1F7RxymD+bCETuPg8Kw93mog87zPfIqVZnI+bpzzG75qLuvvfl9vyLj4/XK7FPFjivgqJ+8g7qJ9+hfvI86ifqJ+qnwqF+Crz6yauTV0OGDFGHDh101VVX6cEHH9S1116rihUr6tChQ1q9erWmT5+u5ORkDRkyxCP7O3HihLMPQ2hoqO2Y5s2bS5I+++wzZyPSrHXOlVdPBwAAAE+jfgIAAHDl1cmr9u3ba+bMmXryySf1+uuv64033nAusyxLpUuX1owZM3TnnXd6ZH9hYWF68MEHbZetWrVKO3fu1J133qkKFSqoevXqql27tipXrqw1a9YoOTnZONXzmjVrVKNGDZqIAgCAIkP9BAAA4Mqrk1eS1KNHD3Xo0EELFy7Uzz//rMTEREVHR6t+/fpq3769s6mnJ4SHh2vatGm2y3r16qWdO3dq8ODBatasmTP+0EMP6aWXXtKIESM0ZswYZ3zEiBE6ceKEnn/+eY/lBwAA4A7qJwAAgLO8PnklSVFRUerevbu6d+9eFLvLl4EDB2rRokUaO3astmzZooYNG2rz5s365ptv1LhxY/Xr18/XKQIAgPMQ9RMAAMAZDsuyzG56xVCvXr00a9YsrV271uWbQ+lMw9EXX3xRCxYs0IEDBxQTE6OOHTtq2LBhioqK8mge8fHxzsPo4+LiiqRBKfzDihYjjNgNPw51a127prCPHelhxB63afb3lk2zPzsv2jRTfTHdvXU9ISExRc1HL5MkfVNyti50uJ6e2bI7vfJ/fzFC1sv1jVhIhHn650N/mK+9dSvM5p/X37LWiKWfOjPvf6hEuO4rd4skqe+HRxWVfLbhqN3jY9ewdngR3sfZudsYsjhbdPlrRmx/wgVGbPfRMCM2wc3mmM+XMBtrjsp0b93Xo2cbsacTzcbPdkaGfmTE/nuqi1vr4iw+s6mf4HvUT7mjfipa1E/UT8ibtz6zvX7k1alTp7Rw4UJt2LBBx44dU0ZGhjHG4XDovffe82oeM2fO1MyZM22XRUdHa+LEiZo4caJXcwAAAHAH9RMAAMBZXp28+vPPP9WmTRvt3r1buR3gVRTFFwAAQCCgfgIAAHDl1cmr/v37a9euXerevbt69+6tKlWqKDi4SNpsAQAABCTqJwAAAFderYSWLVumG2+8UbNmzfLmbgAAAIoN6icAAABXXp28yszM1FVXXeXNXRR7s6tONWLd/nrYB5n4zsyLzNN399r/kA8yKRx3m4vasWteacfd5qJ2dmSa/VRGhJhNKYee9n5Tyv3/q6a0dNcmoSuWm81Au1kOI+YY8rMR29KmpxH77se6Rsyu+efgEmWN2I2N9kiSjoSFSNecifXYfo9iosONsXlt31eqhZwX5+rIVWqq2UjU3deau9xtLmrH3eaidmguGtionwqP+on6SaJ+kqifPI36ifoJvmNz+gnPadq0qX777Tdv7gIAAKBYoX4CAABw5dXJqzFjxmjZsmWaP3++N3cDAABQbFA/AQAAuPLqzwa/+OILtWrVSp06dVLLli3VsGFDlS5d2hjncDg0dGjBDwkGAAAoLqifAAAAXHl18urFF190Xl6xYoVWrFhhO47iCwAA4AzqJwAAAFdenbxavny5Nzd/XnC3uej3TUcZsfCIVCPWYvlLbm3vrqAPjNjCjO5uretpgdhcNBAdLJFmxOac7u2DTKTYq3apUolkl1jluvHGuJAIM2e75qL1vjXP2HXl2CuM2Kd1DxuxR3qZDUxDwk9Jkg45wiVdaiyXpOkx041Y7wTf3J92Dp82fzU+IfJDI/ZMcteiSMcnjhyL8Ml+B5WYZ8TGFqIxaXHW12E2PX67EI2VAwX1U+FRP1E/FRXqJ+on6qeiQf3kvuJaP3l18qply5be3DwAAECxQ/0EAADgyqsN2wEAAAAAAIDC8OiRV3/99Zck6aKLLlJQUJDzujuqVq3qyVQAAAACAvUTAABA7jw6eVW9enU5HA799ttvqlOnjvN6XhwOh9LT0z2ZCgAAQECgfgIAAMidRyevevToIYfDoejoaJfr8L4bf3reo9uzay76ca3JRuy+XY95dL93BL1vxJZk9PDoPmDvqMNs3ukrSfHlVdKKdImdTIw0xgWHljVi3/1Y14jZNRe1Bm03Yne/sNiI/d7pSSMWdeExSVKYdTY27ZJPFZV8NtAvyX+ai46PMBuJHrP51fhrxbi5qJ35iRlGrG8R7DfRsvIeFAA+iH3XiHWP6+PRfRSH5qLuoH7yHeonFBb1E/UT9RP1U35QPxWcRyevZs6cmet1AAAAuKJ+AgAAyB0N2wEAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH7LYVnFpPNZgIiPj1dsbKwkKS4uTlWqVPFxRoB/SEhMUfPRyyRJawe3Vkx0uMvy3T0fMdb5aeVVRuz+fY8asU/rvmnE7v7DbCR6LK2mESsTtqfAOQOB6Nd7nzJil81/wweZ+B6f2f6DxwKwR/0E+Afqp7O89ZnNkVcAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/FVxUOzpx4oR27Nih5ORkXXfddUW1WwAAgIBF/QQAAFAEk1f79u3T008/rS+//FKZmZlyOBxKT0+XJK1Zs0Z9+vTR5MmTdcMNN3g7FeRgSNA8I/ZtiWNG7KfTZsPHAQ5z3VM2+3jD6lSQ1ALCtEozjNhDBx7w6D7Ghc8xYqEhmUasX1I3j+63KMypPkWSlBgeJLWvLEmKHzhApzJTXMaFhJnnlrj+lrVGbHCJskbskV4/G7HfO5kNRy+ZZzYXtWtCeuiBmyVJh4NKShfdKEl6u9ZClTpxNseBKfcb69n54spXjVjCIfM27DscYcQqR6cZsceO9DBiI0M/MmL/SzefP3Myu+aYp6e8Vnq2EQvE521h9HKYj8dMq4sPMrFn11x0cAnzvX50pvm+fmvQTCP2ZUYvI9axhPk8+CTTs88Du8+n8QH0WUT95P+onwqH+qlwqJ+onwLxeVsY1E/UT1792eBff/2lZs2a6csvv1T79u3VvHlzZT+5YdOmTfXPP//oo4/MJyIAAMD5iPoJAADAlVcnr4YNG6ajR49q5cqVmj9/vtq0aeOyPDg4WNddd53WrFnjzTQAAAACBvUTAACAK69OXi1dulQdOnRQixYtchxTrVo17d+/35tpAAAABAzqJwAAAFdenbw6cuSIqlevnusYy7KUlmb+7hgAAOB8RP0EAADgyqsN2y+88ELt3Lkz1zHbtm1T1apVvZlGQBsVZvazaHH1LiN2w49DC7yPlzPMBmxrg6e7tW5kkNkEMiTTUeBc7i7xgRH7NLN7gbfnaetuHGLEHjrwshG7x6aZ3oJCNNNzt3mlnWHBc43Y8PTORqxpyDtGzK7JrKfdv+9RSVJCYorGjl4mSUo9Hq6UDNe59QvrxBvrJv59gRG7sZHZNDQk3GyDG3XhMbfyy2ouml3FGV9LkqzEMtKrZxqO9t11l2Kiw93aZna3/fKffK+TX/89ZTaz7OMwnxdFwZ+ai95s0xzza5vmmP1sGle+VojGlZFy7z1yYtSHRqz/ce83hbVj11zUjl1zUTuebi5qx1+aixYE9VPhUT9RP0nUTxL1U2FQP9mjfnIf9ZNnefXIqzZt2ujzzz/XL7/8Yrt89erVWrZsmW699VZvpgEAABAwqJ8AAABceXXyasiQIQoPD9f111+vkSNHateuM994ffXVVxo6dKhuvvlmlS9fXs8++6w30wAAAAgY1E8AAACuvPqzwerVq2vp0qXq3Lmzhg4dKofDIcuydPvtt8uyLFWtWlXz589XTEyMN9MAEGCOBIWZQSvCCCWVMA8zPxIWYsQOOcxxYeYvNnQqMcWIHQ4qaaaSWObMsuOlz+4jKdXcoB9LjSr4z1MAeBf1E4CCoH7yPuonwHcclmXZvAV5Vnp6upYsWaKffvpJR44cUenSpdW0aVO1b99eoaGh3t69X4mPj1dsbKwkKS4uTlWqVMn3Nt4sY/Y1ePJYwfsaLL7iNSO29lezILb7ze6COpOM2D07nihwLiNDzR4Vdr839yc/tfmvEWv67UiP7uO7JqON2E3rBxuxqRVmGrGHD/fyaC7umlJ+lhF79J+eRuznOwdIkv4JDtODdXI+sxa8b9+Y24yYp1/jK1qMMGKF6TlTGEOCzF4Mdj1sCmNO9SlGLKtPSXE0tuQcIzYo1ew54+nPMTueeO564jO7MKifzqJ+yh31kz3qJxQF6ifqp8KifnKPV4+8cu4kOFgdOnRQhw4dimJ3AAJQ+fQ0Lfp1udpf1srXqZy3qj/3hdYObl2gxqkAPI/6CUBeqJ98j/oJKBpenbzKyMhQcnKySpUqpRIlzPZaWcsjIyMVFBTkzVQABIj3dvyoy2aYZyVa0Nj8RiI5xTw8vsf2e9zaz7RLPjViD/1+txF7u9ZCI9Z3112Szhzq3v6tHyVJs/u8ogpRSc4xpcPWGOvt6mt+Q1brbfObtC1dxhmxqz4aaMTW3/uqEWsy3zz7zspb3jZiLb/q67yc/XYA8D3qJwD5Rf1E/QQUd16dvBo+fLjGjRunuLg4VahQwVh+5MgRVa1aVYMHD9YLL7zgzVQABIjy6Wm231xFp2QasRLJZszdb72iks1fTNutW+qEe+MqRCXpwuhjzutlwswxiRlpbm3rr9PmqantxpU7ddqtcWXT0t0aB8A/UD8ByC/qJ+onoLjz6tkGP//8c9144422hZckVahQQTfddJMWLVrkzTQAAAACBvUTAACAK682bC9TpowefPBBTZgwIccxAwYM0PTp03XkyBFvpeFXfN38tSgUpsFeIDYchf+bHjPdiPVO6F3o7SYkpqj56GWSZPQ6OJZW0xj/zeUDjNh9ux4rdB4FMfmC952Xj0eW0Ntdy0oybwdwPvPVZzb1k4n6KXfUT/AG6icT9ROQN299Znv1yKvTp0/b9mrIzuFwKDU1sE6RCgAA4C3UTwAAAK68OnlVq1YtLVu2LNcxy5YtU40aNbyZBgAAQMCgfgIAAHDl1cmru+++W1u3btULL7ygjIwMl2UZGRkaOnSotm7dqo4dO3ozDQAAgIBB/QQAAODKq2cbfOaZZzR37lyNHDlSc+fOVatWrXTRRRdp//79Wr58uXbv3q1LL71UAwaYv2MGAAA4H1E/AQAAuPLq5FWpUqW0atUq9e3bV5999pl27drlXFaiRAnde++9mjx5skqVKuXNNFDE3G0uatcE8r+nCt8Esjj6uNZkI+arRpX+ZFjwXCM2PL2zEfNEc9G87Oo71OVUzr9sMv+pbPu/8Ubs3Ypmc88+hx7wbHI2DiaFOi8nZzq8vr+itOq64Ubs+tXDjNi2Dv2NWL3PJnolp4L4sNo7Rqzrn4/4IBP/8m7FGUasKF4zRYn66fxE/eR51E/2qJ8KjvqJ+ilQFYf6yauTV9KZ0znPnz9fBw8e1MaNG5WYmKgyZcqoUaNGqlixord3DwAAEHConwAAAM7y+uRVlgsvvFC33XZbUe0OAAAg4FE/AQAAeLlhOwAAAAAAAFAYXj/y6tdff9WkSZO0YcMGHTt2zDhrjiQ5HA7t3r3b26kAAAAEBOonAACAs7w6ebVy5UrdfPPNSktLU3BwsC688EIFB5u7tCzLm2kEtNlVpxqxbn89XODtzbxomhHrtf+hAm+vMIqiCWRxYddcdEk9szHiHdvMBoqFMSLEbOg59LTZ0NPT7BpBrlje0IgNT+/u9Vy+uPJVI3bbL/8xYrXeHqGY6LPNQy+x2ZZdc9GOcSNsRnq/eWL2xqwJiSmaP3qZJOnjRh8p+mSmc5mv3h/m1pxixDrvca+Z8c/bahqx623GHT8WZcQ+u+QNI9bh96fc2u+ksu8bsaAS5ufb5ZftM/OzaYgaiM1FB5WYZ8TGZnYq8Pbsmwqbr4/RJT8yYoNTu7i1D09/znoC9VPhUT9Bon6SqJ88jfqJ+skbqJ/c49XJq+eee07p6emaNm2aevbsqaCgIG/uDgAAIOBRPwEAALjy6uTVzz//rM6dO6t3b74hAgAAcAf1EwAAgCuvNmyPjIzkdM4AAAD5QP0EAADgyquTV7feeqtWr17tzV0AAAAUK9RPAAAArhyWF7t9Hjp0SNdee61uvvlmjRkzRhEREd7aVcCIj49XbGysJCkuLk5VqlTJ9zbsmqNd2+YnI1b9vffc2t6KFmbDw41bzYZ9A052NWLfNh5jxNpseM6t/RYXv95rNiO8bL7ZtLAwfmrzXyPW9NuRHt2Hp827+G0j1ml3XyO2q5vZRLLWbLPZ5OIrXjNid27vV6Dc8mNapRlG7KEDZxoeJiSmqPn/N+qc/MtGlTt9yjmmMI/PsTTz9VcmbI8R+6X9M0bsykUTjNiPrV4wYi2Wv+S8nP12rB3c2qVxqqdtumWQEbv6q7Fe2x/yrzDvae9WNF8vfQ6ZDUKLosmnJz6fPPGZXRDUTybqp+KH+ske9RP1kx3qJ/9H/XSWt+onr/a86ty5s0qVKqW33npLM2fOVJ06dVS6dGljnMPh0Pfff+/NVAAAAAIC9RMAAIArr05erVixwnn5xIkT2rx5s+04h8PhzTQAAAACBvUTAACAK69OXmVmZnpz8wAAAMUO9RMAAIArrzZsBwAAAAAAAArDqw3bsztx4oR27Nih5ORkXXfddUWxS7/kq+av8IzXo2cbsacTu/kgE/83LnyOERuYcr8PMimcIUHzjNjLGZ0kFW2jTrsmpBuuNRs0pp82D6i9ZeuAXLddlLcDRcOuoeeJk2FG7NF/ehZFOgHLHz6zqZ/O8IfHAgVH/eQ+6ifPon5CflA/eYa3PrO9fuTVvn371L59e5UtW1aNGzdWq1atnMvWrFmjyy67zKW3AwAAwPmO+gkAAOAsr05e/fXXX2rWrJm+/PJLtW/fXs2bN1f2A72aNm2qf/75Rx999JE30wAAAAgY1E8AAACuvDp5NWzYMB09elQrV67U/Pnz1aZNG5flwcHBuu6667RmzRpvpgEAABAwqJ8AAABceXXyaunSperQoYNatGiR45hq1app//793kwDAAAgYFA/AQAAuDI703nQkSNHVL169VzHWJaltLQ0b6aBPHzbeIwRW/9zNSP231NdjNiX9ScYsVt/fsYzifkhu+aiv7Q3b++Vi8z7pTB+aPmiEbt2pRnzJ+42F/2905NG7JJ5bxqxBXUmGbF7djyR/8TyqXK0e+9P6+99VeVOnXZeL8zjY/ecOvi32Vy08Q9mU8nfbzXv95XXvmTEWv7wQgGzK5x1Nw4xYs2+f9kHmRRv5cslGrHICLPhqKdNKvu+EXviaA8jNj1muhHrndDbo7kE8ucT9VNgoH5yH/WT+6ifXizwPqmfUFjUT/79+eTVI68uvPBC7dy5M9cx27ZtU9WqVb2ZBgAAQMCgfgIAAHDl1cmrNm3a6PPPP9cvv/xiu3z16tVatmyZbr31Vm+mAQAAEDConwAAAFx5dfJqyJAhCg8P1/XXX6+RI0dq165dkqSvvvpKQ4cO1c0336zy5cvr2Wef9WYaAAAAAYP6CQAAwJVXe15Vr15dS5cuVefOnTV06FA5HA5ZlqXbb79dlmWpatWqmj9/vmJiYryZBgAAQMCgfgIAAHDlsCzL8vZO0tPTtWTJEv300086cuSISpcuraZNm6p9+/YKDQ319u79Snx8vGJjYyVJcXFxqlKlio8zKpxFl79mxNr/r1+R5wH4QkJiipqPXiZJWju4tWKiw722r68ajDdiZcsdM2KXfDnHiG26/iEjduNPzzsvF+XtgO/Mu/htI9Zpd18fZCK9XW6WEev7b08fZJI7X39mUz+d5evHwtOon3A+o35CIKF+yj9vfWZ79cgr506Cg9WhQwd16NChKHYHAAAQ8KifAAAAzvBqz6vWrVvr/ffN0z5mN3v2bLVu3dqbaQAAAAQM6icAAABXXp28WrFihfbt25frmD///FMrV670ZhoAAAABg/oJAADAlVcnr9yRnJyskJAQX6cBAAAQMKifAADA+cTjPa/++usvl+vHjh0zYpKUkZGhuLg4LViwQNWrV/d0GsiHT+u+acRKlMg0Ynf99rQRS0kp6ZWcsvuk9ltGrOPOx72+X3f92OoFI9Zi+Use3cfSq8cZsXabBnp0H76y+VbzdjT80ry902OmG7HeCb0LvN/xER8asQEnuxqxkaEfGbH/nupixFbe8rbKpqU7rxfm8bF7Tt2y1XxOrbzWjNk1F7161TSbvTxvE/O+75uOMmLZm5/Ce4qiueiIkLlGbOjpzkbsisv3eT2XuTWnGLHOex71+n4Livop8FA/FQ71U+FQP5mon+AN1E/+Uz95fPKqevXqcjgckiSHw6HXX39dr7/+eo7jLcvSK6+84uk0AAAAAgb1EwAAQM48PnnVo0cPORwOWZal999/X/Xr11eDBg2McUFBQbrgggvUunVr3XzzzZ5OAwAAIGBQPwEAAOTM45NXM2fOdF5euXKlHnjgAT311FOe3g0AAECxQf0EAACQM49PXmW3d+9eb24eAACg2KF+AgAAcOWwLMvydRLnk/j4eMXGxkqS4uLiVKVKFR9nhEAw+YL3jdhjR3r4IBP/8rDDbG5YLcR8Szt82jyx6jGZTXVnWmYj0ftLmI1JI60gSVJqlEOrHyslSVo7uLViosOdY+wes4NJoUZseLrZjLEoHEur6bx8MLGM2r06QpJ5O4qzW4NmGrEvM3p5fb9POeYZsTesTkbs9ejZRuzpxG5eyQn2+Mz2HzwWKAjqJ3vUTwVH/UT9hLx56zPbfEfysO+++0633nqrKlSooJCQEAUFBRl/wcFePQAMAAAgoFA/AQAAnOXVqmfBggXq1KmTMjMzVa1aNV1yySUUWgAAALmgfgIAAHDl1UropZdeUnh4uBYtWqTWrVt7c1cAAADFAvUTAACAK69OXv3xxx/q3r07hReAYu9QUqrL9eOR5q+ykzMdRiwhMcVrOeUmKa2M8/Lh46Wdl8+9HYHofOk5geKL+gnA+YL6yb9RU8GfeLVh+0UXXaR7771Xr7/+urd2EXACpeGoXSPHqZZvGiMWxtvlZhmxvv/29EEmgWlEiPk8GHo68J4HEyLNpqHPJHct9HYTElPUfPSyQm8HnrVvzG1ujetr8z73dgC+z/mTQSXMZqpjM81mqi/ZvLe8UIj3ltElPzJig1PNBsLu+rbxGEnS4VOJ6vrLmctF+ZlN/WSifipa1E+FQ/2UO+qnwGFXU1E/eR71k3u82rD93nvv1Xfffaf09HRv7gYAfCImOtztiRIUnerPfeGzb2QBT6B+AlCcUT8FDmoq+BOv/mxw1KhR2rhxozp16qSJEyeqatWq3twdAPjE2sEF/2nPx43Mbzzu21jwbzwK4lBSqtq/9aMkaXafV1QhKsm5rHTYGmN8wuD+Rixm9EQj9u1N04xYm+8eMmJft5xuxC6uu8+I1Z76khHLLvvtAAIZ9ROA8wH1k3/UT3aoqeCPvDp5Va9ePZ0+fVrr1q3TwoULVaZMGUVHRxvjHA6Hdu/e7dF9f/bZZ5o8ebI2b96s5ORkxcTEqFmzZho3bpzzsHNJSkpK0osvvqgFCxbowIEDiomJUceOHTVs2DCVKlXKozkBKJ4K0w8g+mSmR7dXWBWiknRh9DHn9TJhZi4ZlvkNnF3OZVPNo0bsxpVJzTBi5TPS3FoXKI6onwCcD6ifqJ+A/PDq5FVmZqaCg4NdvjG0a7HlybZblmXp0Ucf1dSpU3XxxRerc+fOioqK0t9//62VK1fqzz//dBZfycnJatmypbZu3aq2bduqS5cu2rJli8aPH6+VK1dq1apVKlmypMdyAwAAyAv1EwAAgCuvNmz3hddff139+vXTY489pjfeeENBQUEuy9PT0xUcfGbObtiwYXrppZc0aNAgjRkzxjnmueee09ixYzVq1CgNHjzYo/l5ouHo0CCzUduIDJrk+UpWY7rs2mx4zgeZSKPCzEOon08r2kOoz0cL6kwyYvfseMIHmRRM9sapawe3dvmG7lhaTWN8mbA9RZZbfuR2O3xlUtn3jdgTR3v4IBMURKA0CfcE6icUNeonUD/5L1/XVNRPgc1b9ZNXG7YXtZSUFA0fPlw1a9bU66+/bhRekpyFl2VZmjZtmkqVKqWhQ4e6jBk6dKhKlSqladPM3xsDAAAUJ9RPAADA33n1Z4PZ/frrr/r999+VnJys7t27e2Uf33zzjY4ePaoHHnhAGRkZWrx4sXbs2KEyZcropptuUq1atZxjd+7cqb///lvt2rVTZGSky3YiIyN1zTXXaOnSpYqLi3Pp8ZCX+Pj4XJcnJCTk70YBAIDzFvXTGdRPAACc37w+ebVhwwb16dNH27Ztc8ayiq9Vq1bp5ptv1ty5c3XnnXcWel+bNm2SJAUFBenKK6/Ujh07nMtKlCih/v37a/z48ZLOFF+SVLt2bdtt1a5dW0uXLtXOnTvzVXzlZywAAIAd6icAAICzvPqzwf/9739q3bq19u7dq/79++uWW25xWX7dddepfPny+uSTTzyyv0OHDkmSXn31VUVHR2v9+vU6fvy4Vq1apTp16mjChAl6++23JUmJiYmSZHv2HkkqXbq0yzgAAICiQP0EAADgyqtHXg0bNkzSmW/0atWqpeHDh+urr75yLnc4HGrevLk2bNjgkf1lZp45ZWpoaKgWLlyoypUrSzpT5H3yySeqX7++JkyYoL59+3pkf3bi4uJyXZ6QkKAmTZoUah80F/UvvmouaseuuejUCjON2MOHe3k9lxEhZmPcoaeL53M3kJqL5iVhcH+XUzlXedtsLupuE9LdPR4xYhe//04hMwwsNBe19/VVrxixf/41J0O6/fWwW9srzPvNzIvM/ky99j/k1rreQv1kon4qfqif7FE/BSbqJ8+ifrJ3vtdPXp28Wrlype655x6XXgnnqlq1qr7++muP7C/rW8BGjRo5C68sV1xxhWrWrKldu3bp2LFjzrE5fTOYlJTksk13FeczEQEAAO+jfgIAAHDl1Z8NHj9+XBUrVsx1TEpKijIyMjyyv7p160qSypQpY7s8K56SkuLs1ZDVu+FcefV0AAAA8AbqJwAAAFdePfIqNjbWpdGonc2bN+viiy/2yP5atWolSfrtt9+MZadPn9auXbsUGRmpChUqqFKlSqpcubLWrFmj5ORklzPmJCcna82aNapRowYNRAEAQJGifgIAAHDl1SOvbr/9dn3zzTf67rvvbJd//PHHWrdune666y6P7O/iiy9W27ZttWvXLk2b5vobzDFjxujYsWPq0KGDgoOD5XA49NBDD+nEiRMaMWKEy9gRI0boxIkT6tOnj0fyAgAAcBf1EwAAgCuHZVmWtzZ++PBhNWzYUAcPHlTPnj114MABffnll3rzzTe1du1affTRR6pataq2bNmS794IOdm9e7datGihQ4cO6bbbbtMll1yiLVu2aNmyZapWrZrWrVunSpUqSTrzDeE111yjn3/+WW3btlXDhg21efNmffPNN2rcuLFWrlyp8PBwj+SVJT4+3vltZFxcXJ49Hr5qMN6I3bJ1gEdzAorK901HGbEbf3reB5kgu4TEFDUfvUyStHZwa8VE5/99z90mpHZWtBhhxG74cWi+c/DE7fB3m24ZZMSu/mqsDzLxvKVXjzNiu/dWMmKPHTGbuE6rNMOIPXTggULnlN/PbE+hfjJRP+F8Rv3kn4pL/WSnuNVU1E/Fo37y6pFXFSpU0MqVK9W4cWO99957+uKLL2RZlp544gl9+OGHaty4sZYtW+axwks68+3hxo0b1atXL23atElvvPGGdu7cqccff1zr1693Fl6SFBkZqZUrV6pfv3767bffNGHCBP3+++965pln9P3333u88AIAAMgL9RMAAIArr/a8kqSaNWtqzZo12rp1q9atW6cjR46odOnSatq0qRo3buyVfcbGxmrGDHMW0U50dLQmTpyoiRMneiUXAACA/KJ+AgAAOMvrk1dZGjRooAYNGhTV7gAAAAIe9RMAAEARTl5lSU9Pd55B54orrlBISEhRpwAAABBQqJ8AAMD5zOOTV3v37tXy5ct17bXXqk6dOi7LPv/8cz344IP6559/JElly5bV5MmTdd9993k6jWKD5qIoTmgu6v++vWmayqamO6/fsa2/MWZ3j0eM2MXvm81F7ZqQbm9rNouUgtzKza4hZbtNA91at7goLs1F7RTmsbRrLmr/PH3Hre29XW6WJOlo5pEC55Rf1E+eRf2E4oT6yf9RP/k36id7gVY/ebxh+7vvvqs+ffooLCzMJb5r1y7dd999Onz4sKpWrapLL71UR48eVdeuXbVlyxZPpwEAABAwqJ8AAABy5vHJqx9++EENGjRQtWrVXOKvv/66UlNT9fjjj2vv3r3avn27FixYoIyMDE2aNMnTaQAAAAQM6icAAICceXzyau/evWrSpIkR//rrrxUaGqpRo0Y5Y3fddZeuu+46rV692tNpAAAABAzqJwAAgJx5fPLq8OHDKl++vEvsyJEj2r17t5o2baqoqCiXZVdddZX279/v6TQAAAACBvUTAABAzjzesD0kJET//vuvS2zTpk2SpEaNGhnjIyMjPZ0C8umrBuON2LrtVYzY8PTORmzR5a8Zsfb/6+eJtALGplsGGTFPNwVc0WKEEbvhx6Ee3YevbL+7nxG74tPXjNic6lOM2P37HvVCRq5eKz3biPVL6uZy3dOPj7vPqXU3DjFizb5/2Yh933SUEcup+Wub7x5STHR4rvm527TRrrnoFd+8b8S2tjKbRdo535qLBqKJUR8asf7HuxqxrIae2fX9t6dHc9m+6VIjdrFH9+BZ1E+Bh/qpcKifCof6yUT9ZI/6yf9RP7nH40de1alTR99//71L7JtvvpHD4VCLFi2M8X///bdiYmI8nQYAAEDAoH4CAADImccnr+655x7t3LlTjz76qH755RfNnz9fU6dOValSpXTzzTcb49esWaNatWp5Og0AAICAQf0EAACQM49PXvXr10/16tXT1KlTddVVV6lTp046fvy4hg8fbhzivnHjRu3atUtt2rTxdBoAAAABg/oJAAAgZx7veRUREaE1a9Zo4sSJWrduncqVK6eOHTvqjjvuMMZu3rxZ7du315133unpNAAAAAIG9RMAAEDOHJZlWb5O4nwSHx+v2NhYSVJcXJyqVDEbe2a3+IrXjNid2/t5ITNXg0vMM2KjMzt5fb+eZtekMiw03Yjds+MJr+eyu+cjRuziWe41bgS8KSExRc1HL5MkDft6n8qkZjiXdfj9Kbe2Ydd01V0Nls8wYo6xVxix6BcW57qd7Ldj7eDWeTZOhf9zp+GvN+X3MxveQ/1UtKifgLwVl/rJDjVVYCuu9ZPHfzYIAAAAAAAAeAqTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/l8bMNwrOKormonUBsLmon7VSIEcvM9M2cbSA2Fx0XPseIDUy53weZFF9za5pNcTvvedQHmZxxcd19Kp+Rlu/1bvhxaIH3mfjSBiNmDdpuxD6t+6YRu/uPJwu8X3jesOC5Rmx4eucCby/lVJARs3vNJByOMmL9j3ct8H7Hljzz3pdo/VvgbcC3qJ8Kh/qpcKifvI/6ifqpOKF+cg9HXgEAAAAAAMBvMXkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwWzRsR7H2wN8P+jqFgFaY5qIToz40Yu42APy41mQjdt+uxwqciz/zZXNRO7WnvqSY6HCPbGvp1eOMWLtNA41Y9AuLjZhdc9HWv0w0YsuaJTkvHwkLkZpf7nZ+/R3zjNhEq3g0W/aVwjQXtTM4tYtb4+zeb2ZXnWrEuv31sBGze79p2vBMo9HDaYnSZrdSAIoV6qfCoX7yPuonz9VPznHr/utWftRPnkf95B6OvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt2jYDsAr3G0uaqe4Nhc939g1F3XX3X88acTsmos2XPme8/LBxDLSqyPc3kdxaS666ZZBRuzqr8b6IBPPm1ZphhF76MADRqww7zdly5rPqxt+HCpJio+Pl2InFHjbAJBf1E8o6vrpLPcatlM/+b/iWj9x5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0fMKAOB0KCnV1ynk6EhYiBE7mFjGefnw8dLOy/58OwojJjrc1ykAAAAARY7JKwAoIquuG27Eft5W04g9eax7UaRjq/1bP/ps33lqfrkZy6FBu1/fjkLYN+Y2I+Zuc9FRYR+Z614RZ8QK0yjW0+yai3pamw3PeX0fAICCC4T6yZ+1XmfXiN2MHUs7e58mpZWRZF9jdS7xoRGbm1nwxt92xpacY8QGpd7v0X1QPxWOL+onfjYIAOe5mOhw20kR+J/qz32hhMQUX6cBAAAAFCmOvAIASJLWDm7t6xQK5VBSqvOIq9l9XlGFqLOn8C0dtsYY/1jsZ0ZsclwHj+Y0+eKF5n5335Xv7WS/bQAAAMD5hskrAICk4tVPqUJUki6MPua8XibMvG1hJywj5un7oFQR7AMAAAAo7pi8AgAAAACggIrDiWLO9Lk6I7eT4KSVchjrerqlwQk398EXgucXJq+Ksd87PWnELpn3pg8yASBJ168eZsZ8kMf5oHTYGpejrbI3Ic3y8v1tbdZ0r+Hovt4PGbHq06cZsXY3bTFi/wwyf6646bvGRqzpbWd/JphkRUoqXKPS59O6FGp9fzG35hQj1nnPoz7IBMUV9RPgXwKhfioeP+138yQ4j0UbY5qPXubZVB4qbYQ+sNnHO9/+z4hlr5+ylHlpYYFToX7yHzRsBwAAAAAgHzjhje890uZyHQ3jeJzzBY80AAAAAAAFEOgnvLGT20lwjjxrHvdW/Y3Rbm037plnjVjshFeM2P96jjRiMXXjnJf/Ubh6Ou5wa58oPpi8AgAAAACgAIp736VzT4ITlGH293L3PkjLdG/dg+lpRuxCnXRrHyi++NkgAAAAAAAA/BZHXgWgNsEzjNi36Q8YseLSXLSvY64Re9vq7INMfGdI0Dwj9nJGpwJvr7fjIyO2ODTOiDVKr2jEvs7o5dY+bguaZcS+yOjp1rpPOczbe8iRbsS6XHrYiKWmhhmxI8cijNj8xAwj9n16b7fyuzlopsv1RjK/MbJ7fLZ16G/Ejh+LMmItlr/kVh6Fces5t0GSqmWWNGL+9Frrb/O8mGjZvw4ei/1MYScs53W75uzl3/vGiB0febsRO/pnBSP22+bLjVipQR2N2KW3mc/RkOpHjFi7sZ8YsSX1Jp7NoWSwdKMx5LwUaM1F4T+on/zrPb0oUD9RP3laca6fOpf40Hk5rZTD2Zj9yLPXuxxt5Q/1U1paaWndmcstv+rrcvRW9vopyx3ef2r4veJQP3HkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/5bAsy8p7GDwlPj5esbGxkqS4uDhVqVLFxxkBgWvyBe8bsceO9PBBJgX32SVvGLEOvz/lg0wCX0JiipqPXiZJWju4dZ6nbbZrLpox4Fcj9mfHu43Y4QPljFi9a7YZse8/u96IXX/zOiNWZcrMnNKUlP/bBs/gM9t/8FgAnkP9hLzkVnf4Q/10yBGuu6Nvt80Pvuetz2yOvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt4J9nQCQXS/HR0ZsptXFiL1bcYYR63PoAa/kVByNLTnHiA1Kvd8HmRTO7qNhPtlvP8c8l+uvWZ0KvC2ai/rO0T8rmDGb5qLVPvnUiNUYd7kRCyp52ojdcPsaI1Z50gfupggfeer/X+Mn9K+PMwHcQ/1UNKifCof6qXjwh/opKDFF+v+G8vAf3q6fOPIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN+iYTtsDS4xz4iNzix4U0V31Q5xb5xdc9HpMdONWO+E3oVNqVgKxOaidiYUotFnYRSmwSh8Y1/vh4zYb5vNpqEhoWbTULvmopkD/2fEUp5rZsSOHShrxCrnmKWrpVePc14+GhYsXV/XzTVRWG/8/2s8Pj5eM2If93E2CCTUT8Ub9VPhUD8FprhnnlVaZqrzeiDVT1nabRro5tooDG/XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0bAdtoqiuaidfacdBV6X5qIIRJPKvm/EnjjawweZFG/Vp08zYqUGdTRiGafMrsdBJc0mpHbNRcPGrDNi5WzG/fWw2TC56tQZRix7c9GExBRp9DJjTKAa4DCbWo/3o0a+Wfkd178+zgSBhvoJKBrUT0UndsIriokOd173h/rpkCNcKnubbb7FuTn7+V4/ceQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL9Fw/YANKiE2ahtrE2D0E23DDJiV3811q19dHXMMWIfWve7tW5hvGt1LvC6I0LmGrGhpwu+veLs9ejZRuzpxG4+yKRwnrd5LYzyQbPcOdWnGLH79z3q1rpBJSxPp+NRgdoQdfLFC1XqxNn7tt1NW4wxl9522IgtGGu+Z9xw+xojduxAWSNm11zUrglpqdfrmAmfZwrTXPTtcrOMWN9/exYmHUNWfvHx8Zoa+7hHtw3foX6yR/3kPuonz6J+8i9jS559/zpRyiE9VFqS9L+eI3UwPc25zB/qp9OZkdIxY0ixd77XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvOSzL8u9ud8VMfHy8YmNjJUlxcXGqUqWKjzOCN3S3adj6QRE0bIU9uya9iTZvfVNsGt72cnxkxCLlcLn+ViEa5a66brgRu371sAJvz11POcz75I1CNIH0BwmJKWo+epkkae3g1oqJDncu+2dQR2P8BTf8YcT+XtTQiFWZMtOt/f/18ANGrFytBCN2+ukdRmxhzeeNWEpqiPNyUmQJvX3/BZLM21YUxkd8aMQGnOxapDn4Ap/Z/oPH4vxA/eRfqJ9MxbF+spO9pvrC+lgX6qRzmT/UTwcTy6jdqyMkSf0XHFT0yUznsuz1UxZPNyZ3F/WTZz+zOfIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt4J9nQAAAAAAAPA//8i1z2ZaWmljzCGH2YszKDHFre3brXs6M9KIpSeWcV4+fPxsDsfDXY/HSQ0yj89JcDMXTztRymHEfJXLuYq6f6on0LC9iNFwFAC8I7eG7UuvHmeMb7dpYJHllt3Mi6YZsbv2jDJiyf+51nn5kCNcHUrdKck3DdvdNTHKbEza/3jgNiblM9t/8FgAQNHJXlOheNo35javbZuG7QAAAAAAwKtiosO9OrkB36v+3Bd+cxSYu/jZIAAAAAAAcDFm1R9GrOVXfX2QifRxo4+cl4+Hl9C0WytIkmb3eUUVopKcy06+1NhYt9LI17yeX2G8W/czI9bnjw5e2dehpFS1f+tHr2zb25i8AgAAAAAALsqmpRsxX7UuiD6ZaRuvEJWkC6OPOa8nW+bRRP7abiFLVLLZycnfc/YFfjYIAAAAAAAAv8WRV37u07pvGrG98RcYsWeSA7chLvLmT82m59acYsQ673nUB5lIr0fPNmJPJ3bz+n7PbUrtbkPqD6u9Y8S6/vmIR3LKL1/dd77S9Dbz8Ogl9SYasTu29Xdre4V5Taakhhix7M3Zs0S++oPzckRiGenVO93avi+dSA3ydQqAJOonnEH9ZI/6qeCon/yjfsp+RsGTLzV2Odoqe/0UKKif3MORVwAAAAAAAPBbxW7yyrIsffrpp2rVqpViYmIUERGhunXr6pFHHtGePXuM8UlJSfrPf/6jatWqKSwsTNWrV9ezzz6rEydO+CB7AACAokf9BAAA/Fmxm7waMGCA7rnnHv3xxx+666679OSTT6pGjRp699131aBBA23fvt05Njk5WS1bttTEiRN1ySWXqH///qpbt67Gjx+v1q1bKzU11Ye3BAAAoGhQPwEAAH9WrHpeHThwQK+99pqqVaumn3/+WdHR0c5lEydO1H/+8x+9+uqrmj59uiRp3Lhx2rp1qwYNGqQxY8Y4xz733HP/196dh0dZ3f0f/0y2ScgqCBJMCBCD0ApFFBEBWSxglYI+/KhIoUEFBKSlgLJVRORRQBGsWsGlCIoCbrhWQUUWMbJfiFYBESRBJKgkIRFCIOf3B09GxjNAApmZO5n367q8mnzvM3N/Z05CPj1zzxlNnz5ds2bN0vjx4wP+OAAA5ya3wPv/PBeYWGvMwWj7T+C+fPsTanw56D772xbE2q8b5brsT5SpkZ/k+frAoYRfxhY4d2GgKM5l1Xw9L3yCjrOQnwAAgNO5jDH25zJWUZ9++qnatGmjvn376oUXvDcE3LFjhxo3bqzu3bvrrbfekjFGKSkpKigo0Pfff6/Y2F/+j01RUZHq1q2rOnXqaOfOnZXaY05OjlJTUyVJ2dnZSklJOe34FVdNsWodP5lYqT2di/dbTbNqXdaPC0InAIJp4x/GWrXL3p0e0B725R9Wm6nLA3pOnJ3d0663aquvnmzV2q+aFIh2Tqmif7OrKvJT4JGfAEjOyE9V0cmZL2t85zO+KJZX3MiqJbntt8R/2PoBq3bN2gln2WVgVDQ/VfS5Oxv+yk/V6sqrjIwMRUVFac2aNSooKFBCwi+vVL/99tuSpGuuuUbSiTD23XffqVu3bl7BS5JiY2PVtm1bLV26VNnZ2Z4nvjxycnJOe3zfvn3lvi8AQPklJ8Zo97Tr1WDcO8FuBWfQYNw7fgtMqDjyEwAAcLpqtXhVq1YtTZs2TaNHj1aTJk3Us2dPJSQkaMuWLVq+fLmGDRum4cOHSzoRvqQTgc2XjIwMLV26VDt27KhQ+KrIWABA5csa3znYLVS63IIj6vmvEx9XvWDQQ6odX+A5luBeY43/+I+PW7V2bw33X4PldPLjgHOQnwAAgNNVq8UrSRo5cqQuvPBCDRw4UHPmzPHU27Vrp759+yoi4sRDzs/PlySvfR1OVvaqY9k4AEDVUN2v5qkdX6ALEvM83ye57cdbs7jEqlX35wXnhvwEAACcrNp92uB9992nfv36acKECcrOztahQ4e0evVqHTlyRB07dtSbb77p1/NnZ2ef9r9169b59fwAAAAVRX4CAABOVq2uvPrggw80adIkjRw5UuPG/bLpZbt27fTWW2+pUaNGGj16tHr06OF5xfBUrwwWFJx4S8apXlk8lcrezNXX5qJzk+datVv33Vqp5y0vNhetPsaHLbZqU0tvCkInvr3a2H4bVK/twX8bFE4I1uaiobjRaYJ7jdfVVr42Ib1mrb0JqdMFe3P2UEZ+CjzyU/VBfsK5ID8Fhq/N2clPVU+1uvLq3XfflSR16tTJOla3bl01adJEX3/9tQoLCz17NZTt3fBrZ9rTAQAAoDogPwEAAKerVotXR48elSQdOHDA5/EDBw4oLCxMkZGRysjIUL169bRmzRoVFRV5jSsqKtKaNWvUsGFDNhAFAADVGvkJAAA4XbVavGrbtq0kaebMmdbl7HPmzFFOTo7atGkjt9stl8ulgQMHqrCwUFOmTPEaO2XKFBUWFmrQoEEB6x0AACAYyE8AAMDpqtWeV71799bs2bO1atUqNW7cWD169FBSUpI2bdqk5cuXKyYmRjNnzvSMHzNmjN544w1Nnz5dmzdvVsuWLbVp0yYtW7ZMrVq10t///vfgPRgAAIAAID8BAACnq1aLV+Hh4Vq2bJlmzZqll156SS+++KKOHj2qCy64wPMJOk2bNvWMj42N1cqVK3Xvvffq1Vdf1UcffaTk5GSNHj1akyZNUkyMMz9WPFibi6J6c9Lmor742lz0/qiFVu0fR28ORDsBt6D+U1bt/Fr2hsnXbr4rEO04RnXeXPRUPv7j46pZXOL53tfmor42Id3W3f7daP3+/ZXbHKok8hNw9shPzkZ+8i3U8tOHrR+wauSnqqdaLV5Jktvt1rhx47w+Led0EhMTNWvWLM2aNcvPnQEAADgT+QkAADhZtdrzCgAAAAAAANULi1cAAAAAAABwLBavAAAAAAAA4FjVbs+r6mbO+fOt2pAfMoPQSfXxz8QFVm1Efr8gdIJzVV03F/Wl8Ge3VYutYdcWp8+2ajftHOqXnpzqAbe9Ee2E4urzs9LureFKTjz9hti+Nhe9+G37eXm/VbxV67K+fHseOcnuWwdatQZznynXbdd3G2/VWi2des49IbjIT5WP/FR9kJ/IT75U5/x0zdoJ5RoXavkpe/RdKi494lVzcn7iyisAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsdiw3eHYXLTysbkoqiL+LSi/yy7JDnYLQdf6/futmq/NRVt9/JSPW5/9hqOf3TDKqjV/feZZ399LFz1h1f709TCrVt7NRX1hc/bqiX8zKx/5CVUR/xaUH/kp9PJT6sMPnfFDgE4lGPmJK68AAAAAAADgWCxeAQAAAAAAwLFYvAIAAAAAAIBjsXgFAAAAAAAAx2LD9ipoQX17g7h+ewYHoROgevnv//ubVfvNK4+GbB9VVbeNY4LdgiN1We9rI1G7llfcyKptvHqgVbtm7QSrdi6bi/ria3NR4GyRnwD/cEpucUofVRX5yTfyk3Nw5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWGzYXgWxuahvD8e+YNVqRB+zakN/zPR7L2Nci63ag+Ymv5+3sk2JXGTVJpb08ft5g7Wprq9NPceH2XM5tdS/c8nmotXbjBr2v1V3/vznIHTim6/NRS9b9YyPkfaGo4CTkZ98Iz9VPvIT+QmV7+T8VBjnkm5NDGI3NvKT/3HlFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYbNgOrbhqilXr+MlEq7bjz0OtWsYLs/3S09kYXeScDY+r4uaivgRic1FfArG56POpT1u1/tmDrJq/NxdF6HHS5uy+XLPW10aidi2vuJFVS3J/44eOAGciP1U+8tO5IT+hOjs5P+3LP6x5U5cHsRsb+cn/uPIKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCw2bIeWfdrYqt0V+aRVW19iby462rXYqj1cBTfbnBK5yKqVd7PNp+s8a9Ve/sket+zYLRXuq8z06Bet2tgjfc/6/sqrd9gCq1bfRFq1c5nzF9Lsn7U/f3u7VRvssufoKXP2G6L62lzUl+vC51m1/xwf4PX9uczP2DD7d+ii83+2aoNy7Z+fx897zqoNP/gXq1ben29fvUyv5A1XZ8W/YNVGHrI3C54UYfc8+VhwNsANBF/PS+GRcM/XRXEu6fa4Sj/vZzeMsmrNX59Zrtv62lzU1yakWa2Heb4+6I6QOmVIkp5r9ooSiko9x77Pd1u33VpaYtVeK+1v1fqG2c9fsrEjTlX8+wTnIj+Rn06F/ER+Ij8FztMXL1F8kfF8f3J+KlPZH6IQ6PxUZnd2bat2LvlpeOoSuQuNV83J+YkrrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHchljzJmHobLk5OQoNTVVkpSdna2UlJQgdwQAcLp9+YfVZupySVLW+M5KTowJcke+vdtihlVrs/YJz9f785PUbeYUSc5+HGX4m+0czAUAoExVyUXldab8VMbXZu8VFYjnzl9/s7nyCgAAAAAAAI7F4hUAAAAAAAAci8UrAAAAAAAAOFZEsBsAAADll1twJNgtnNJBtx0r9ucneb4+cCjB87WTH0eZ/QWHg90CAAAAxOIVJN0ftdCqfVD6s1X76NhtVm1i+CKrNuV4n8pprIpYUP8pq9Zvz+BKPcdjSc9btb/m9a/UcwTLq40ft2q9tg+3aiNdi63aLHOTX3o6We+wBVbt5dJ+Xt9X9vyU92dqbvJcq1Z8NNyqXfLb3Vat/apJVu2+SPv3+Z4S+/f5vUsfsmrXbr7Lqvkyu9Z8qzb0x8xy3dbp7vTxMzrDDz+jPf/1SaXfZ6XplGHX/m+D9l9z9OP4P8cKfgh2C3Aw8tO5IT+dG/KTjfxUNQUqPznZ7uzaVu0PPjZnzytuZNWeTPxfq1anpv3i2y3f2X+LxqS+qehD3p/fV9fHe/N8/X36sPUDVu2atRPsG1ci3jYIAIDDJSfGaPe064PdBgAAABAUXHkFAEAVkTW+c7BbOK3nmr1i1f6y9f95vs4tOOK54mrBoIdUO77Ac2zBb+xXn89Pst9a+KeN9qt/Y1LftGq1XXZ/d+3pYdU+/qN99UK7t05cvbB12051m23fDwAAAAKLxSsAAKqI5MSYYLdwWglFpVbtVD3Xji/QBYl5nu/jCo01JiGqfPf360veJSnWx7Xlvm5bs7jklOO+i3PbdwIAAICA422DAAAAAAAAcCyXMcZ+uRJ+k5OTo9TUVElSdna2UlJSgtyR9NJFT1i1P309LAidAKgKfG2IWrt2nlXrtnFMALoJLauvnmzVfG0eGyyTIuxNaycf++VtfvvyD6vN1OWSpP7PFHhdbXV7/t3WbZN8bFbqy6z4F6zayEN/LtdtT2fjf3fo8t82luScv9mhivwEoKojP1Wek/NE1vjOZ7wyvarnpzLTo1+0ahXNTyc/d7fOy1d8kfdyUGXkJ3/9zebKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxIoLdAIIv1DYXvTt8sVX73+M3BaGT4BkfZj8HU0ur73Mw1GVvgjjb2JsgBkN5N2h0kn57Blu1J2o+d9b390jCAqt2+Gi4VRt/5Gar9kzdZ63awO9vOetenK6yNxet7A2nt5aWlHvs+UlHlBBV6vne1+aiecWNrNqs2AesWka9onKf99emRNq/gxNLnP07CGcgP5GfJPJTsJCfyE8VUV3yU52ah61aRfNTUZxLGhInSaqV+LMST8piFRGM/MSVVwAAAAAAAHAsFq8AAAAAAADgWCxeAQAAAAAAwLFYvAIAAAAAAIBjuYwxJthNhJKcnBylpqZKkrKzs5WSkuK3c229caRVa7Zklt/OB+D0nq5jb445KLf6bo55LhY1mmPV+nwzxDH3V16za823akN/zPT7eZ1qX/5htZm6XJKUNb6zkhNjTjve14a8I4smWDVfm5XOTZ5r1W7dd2u5+ny/1TRJ0g4V6o4N90vy/99snB75CQhd5KfyC5X8VNE8EWpOl5/25yep28wpknw/d5WRnw4czdefPzvxdWX+zebKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgRwW4AAAAAAACgonILjgS7BccpinNZtf35SZKkA4cSPDVfz11BDfv6pn35h8t13p/cJ5aX8hRervEVxYbtARbIDUeBczXYZW/295Tp4/fzPhjzolUbc7iv388bDFOjF1q18UduDkIn5e9lSqT9c5Fcy/6jNvD7s99MdVb8C+UaN/LQn8/6HKFm960DrVqDuc9U6jn6htnz9mLpL3N08gar7Z8oVPShXyLIb+KOW7etfV6RVeu3Z7BVyytuZNU2tB9k1X6/brxV2953mFWLiimWJG09fFw9Fp7YNJa/2cFFfkJVQn7yP/KTb6GSn07OE3CeYwU/aO/sAZLYsB0AAAAAAISg5MQY7Z52fbDbQIDxtkEAAAAAAFClZI3v7PdzZI++y6qlPvxQpZ5jeOoSq/Z49o1WbUzqm1Yto4Z95XqtxJ+t2v+sO3G1XW7BEfX81yeSpAWDHlLt+AKvcVt62Vdrtn/7Dqv2zfB/WLXI6KOSpG0/l+gv1tFzx+IVAAAAAACoUpITY/x+juJSe1+oyj6vu9DeycnXOU7ebqFMvI9doBKjSst1f7XjC3RBYp5XrWZxSblue+i4/bxElZ7YdmG/sRfUKgNvGwQAAAAAAIBjceUVNO9Ce8PeVd/FWrW5xt548Kna86za4AMDKqOtKuP9VtOsWpf14yr1HK82ftyq9do+vFLP4UsgNhddffVkqzbm8CSr5msDykBsNnmna7FVm2Fu8vr+XObH14ae5f2Z+s/vHrZq120ZbdUWNZpj1fp8M6RcvfgysaR8Pxc7/3K7Vft8Y1Or1vOLv1s1X3O7oP5T5TovfKvszdl9STbljxW1XVLsSS+hlff3eW7yXKtWP9XenP3y1U9btR/HbbJqn6zsZtU6X79GkhTmsl+5BMqQn84N+enckJ/IT+SnwHBSfqrr49KjiuanghphUu/akk68RfDXV1o5OT9x5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWC5jfHy2IvwmJydHqampkqTs7GylpKQEuSMAAAJjX/5htZm6XJKUNb6zXz/i+sdxva1a+OSN9rjBXazaf95oJ0nKiT6oB/ePkMTf7GAjPwEAcO7OlMWcnJ+48goAAAAAAACOxeIVAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwrIhgNwAAv/ZigzlWre/uIUHoxP8W1H/KqvXbMzgInZTfvAufsWoD9g70+3lfuugJq3beeQVWrcv6cX7vpSpa3228VWu1dGoQOjnh4z8+rprFJZ7vr1k7wRozJXKRVZtY0seqbe87zKp9srKbVWu/r6ZVq/XU+1atYGFHSVKhwq1jAOBU5Cfyky/kp3PjpPz0YesHrNq55Kdvhv9Dh44f8ao5OT9x5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWC5jjAl2E6EkJydHqampkqTs7GylpKQEuSPg1Aa4Flq1eeZmv5/3/ij7vP846v/zhrr3W02zaueyeefsWvPLNW7oj5lWbXr0i1atdcudVq3jJxMr3lgF/c212Ko9am6yanf6GDfDx7hQti//sNpMXS5JyhrfWcmJMRW+D18/pxnNd1i1sPBSq/bGS52tWsHP9mfX3HHoH5KkLV/WUMdLv5DE3+xgIz+hKiE/hRbyk2/kJ2cp+zn9yR2hse2aSpJe+vFd1Sk97DXOyfmJK68AAAAAAADgWCxeAQAAAAAAwLHsa73gV8eOHfN8vW/fviB2ApxZkX60ajk5OX4/b74JznlD3YGj+VbtXJ73g6U/lWucr3P4+hk4UFy5/ZVXYTl/Dw4F6felKtlfcFjHCn6QJG3dtlPfxbkrfB87VGjVjhw+btXCXPZl7znRB61aocKt2pYva0iStn8T5amd/PcbgUd+QlVCfgot5CffyE/OUvZzmqdwTxbb9nOJ9hvvDOXk/MSeVwG2fv16XXHFFcFuAwAAVMC6devUqlWrYLcRsshPAABUPZWZn3jbIAAAAAAAAByLK68C7MiRI9q6daukE5fQXXXVVZJOrEgmJycHs7WQtm/fPs8rusxF8DEfzsJ8OAdzEVjHjh3TgQMHJEnNmjVTdHR0kDsKXWX5af/+/frjH/8oid8BJ+DfJGdhPpyDuXAW5iOw/JWf2PMqwKKjoz2XzZ38Xt7k5GQ+9tkhmAtnYT6chflwDuYiMBo0aBDsFqBf8hPZybmYD2dhPpyDuXAW5iMw/JGfeNsgAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxWLwCAAAAAACAY7F4BQAAAAAAAMdyGWNMsJsAAAAAAAAAfOHKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxWLwCAAAAAACAY7F4BQAAAAAAAMdi8QoAAAAAAACOxeIVAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwLBavgmT9+vW67rrrlJSUpNjYWF155ZV66aWXgt1WtbR371498sgj6tq1q+rXr6+oqCjVrVtXvXr10tq1a33epqCgQKNGjVJaWprcbrcaNGigu+66S4WFhQHuPnRMnz5dLpdLLpdLn376qXWcOfG/JUuWqEuXLqpVq5aio6PVsGFD3XzzzcrOzvYax1z4jzFGr732mjp16qTk5GTVqFFDF198sW6//XZ988031njmAqGG/BQ45CfnIzsFH9nJGchPIcIg4JYvX24iIyNNfHy8GTRokBk1apRJS0szksyMGTOC3V61M3bsWCPJpKenm9tuu82MGzfO9OrVy4SHh5uwsDCzaNEir/GFhYWmRYsWRpLp2rWrGTt2rOnatauRZFq1amUOHz4cpEdSfW3dutW43W4TGxtrJJmsrCyv48yJf5WWlprBgwd7fk+GDRtmxo4da/r372/q169vVq9e7RnLXPjXqFGjjCSTnJxshgwZYsaMGWO6detmXC6XiY+PN1u3bvWMZS4QashPgUV+cjayU3CRnZyF/BQaWLwKsJKSEpOenm7cbrfZvHmzp56Xl2caN25soqKizO7du4PXYDX06quvmhUrVlj1VatWmcjISHPeeeeZI0eOeOr33HOPkWTGjh3rNb4sxD3wwAN+7zmUHD161LRs2dK0bt3a9OvXz2cAY07865FHHjGSzLBhw8yxY8es4yUlJZ6vmQv/2bdvnwkLCzNpaWkmLy/P69jMmTONJHPLLbd4aswFQgn5KfDIT85Fdgo+spNzkJ9CB4tXAbZ06VLrF6jMvHnzjCQzefLkIHQWmspW2devX2+MOfEqSr169UxcXJwpLCz0GltYWGji4uJMo0aNgtFqtTVp0iTjdrvNF198YTIzM60Axpz4188//2zOO+8806hRI6+g5Qtz4V9ZWVlGkunbt691bPv27UaS6d69uzGGuUDoIT85C/kpuMhOwUV2chbyU+hgz6sAW7FihSSpa9eu1rFu3bpJklauXBnIlkJaZGSkJCkiIkKStGPHDn333Xdq27atYmNjvcbGxsaqbdu2+uabb6z3sePsbNq0Sffff78mTZqk3/zmNz7HMCf+tWzZMh08eFA33HCDjh8/rtdee03Tpk3TnDlz9PXXX3uNZS78KyMjQ1FRUVqzZo0KCgq8jr399tuSpGuuuUYSc4HQQ35yFvJT8JCdgo/s5Czkp9DB4lWA7dixQ9KJX7Jfq1u3ruLi4jxj4F979uzRBx98oOTkZDVr1kzS6efn5DpzdO6Ki4v1l7/8RS1atNCYMWNOOY458a+NGzdKksLDw9W8eXP16tVL48eP19ChQ3XxxRfrzjvv9IxlLvyrVq1amjZtmvbs2aMmTZpo6NChGjt2rK699lqNHTtWw4YN0/DhwyUxFwg95CfnID8FD9nJGchOzkJ+Ch0RwW4g1OTn50uSEhMTfR5PSEjwjIH/lJSUqH///iouLtb06dMVHh4uqXzzc/I4nL177rlHO3bs0MaNGz3Pvy/MiX/l5uZKkmbOnKmWLVtq3bp1atq0qTZv3qzBgwfr4YcfVnp6uoYOHcpcBMDIkSN14YUXauDAgZozZ46n3q5dO/Xt29dzlQNzgVBDfnIG8lNwkZ2cgezkPOSn0MCVVwg5paWlGjBggFatWqVBgwapf//+wW4p5GRlZWnGjBm6++67dckllwS7nZBWWloqSYqKitLrr7+uVq1aKS4uTu3bt9fLL7+ssLAwPfzww0HuMnTcd9996tevnyZMmKDs7GwdOnRIq1ev1pEjR9SxY0e9+eabwW4RQIgiPwUX2ck5yE7OQ34KDSxeBVjZKu+pVnMLCgpOuRKMc1daWqpbb71VL774ovr16+e1Mi+Vb35OHoeKO3bsmDIzM9W8eXONGzfujOOZE/8qe94uv/xy1atXz+vYJZdcokaNGmnnzp3Ky8tjLvzsgw8+0KRJkzR8+HCNGzdOKSkpiouLU7t27fTWW28pMjJSo0ePlsTvBUIP+Sm4yE/BRXZyFrKTs5CfQgdvGwywk99He9lll3kd+/7771VYWKgrrrgiGK1Ve6Wlpbrlllv03HPP6eabb9a8efMUFua9fnum9zmf6X3SOLPCwkLP8xgVFeVzTJs2bSRJS5Ys8WxGypz4x8UXXyxJSkpK8nm8rH748GF+P/zs3XfflSR16tTJOla3bl01adJEmzdvVmFhIXOBkEN+Ch7yU/CRnZyF7OQs5KfQweJVgHXo0EFTp07VsmXL1KdPH69jS5cu9YxB5To5eN100016/vnnfe4VkJGRoXr16mnNmjUqKiry+hSKoqIirVmzRg0bNlRqamog269W3G63brvtNp/HVq1apR07dqhHjx6qXbu2GjRowJz4Wdkf+i+//NI6VlJSoq+//lqxsbGqXbu26taty1z40dGjRyVJBw4c8Hn8wIEDCgsLU2RkJL8XCDnkp+AgPzkD2clZyE7OQn4KIQYBVVJSYho1amTcbrfZvHmzp56Xl2caN25soqKizK5du4LWX3V0/Phxk5mZaSSZ3r17m5KSktOOv+eee4wkM3bsWK/62LFjjSTzwAMP+LPdkFY2T1lZWV515sS/unbtaiSZp59+2qt+3333GUmmX79+nhpz4T8LFy40ksxvf/tbk5eX53Vs9uzZRpJp27atp8ZcIJSQnwKP/FQ1kJ2Cg+zkHOSn0OEyxpjALJOhzEcffaRu3bopOjpaffr0UXx8vF599VV9++23mjFjhuc9uagc9957ryZPnqy4uDiNGDHC82kTJ7vhhhvUokULSSdW3du2bastW7aoa9euatmypTZt2qRly5apVatWWrlypWJiYgL8KELDgAEDNH/+fGVlZenKK6/01JkT/9q5c6euuuoq5ebm6vrrr/dcXr18+XKlpaXp008/Vd26dSUxF/50/Phxde7cWatWrVKdOnXUo0cPJSUladOmTVq+fLliYmK0YsUKz1ujmAuEGvJTYJGfqgayU3CQnZyD/BRCgr16FqrWrl1rrr32WpOQkGBiYmLMFVdcYRYtWhTstqqlslekTvffs88+63WbvLw88/e//92kpqaayMhIU79+fTN69GhTUFAQnAcRIk716qExzIm/7dmzxwwYMMDUrVvXREZGmtTUVHPHHXeY/fv3W2OZC/85cuSImTp1qrn00ktNjRo1TEREhLnwwgtNv379zH//+19rPHOBUEN+ChzyU9VAdgoespNzkJ9CA1deAQAAAAAAwLHCzjwEAAAAAAAACA4WrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQBUEQMGDJDL5dLu3bv9do4GDRqoQYMGfrt/AACAQCI/AdUDi1cAyqWoqEgPPPCAWrZsqbi4OLndbqWkpKh9+/YaP368du7cGdB+AhFEAAAAzgX5CQAqR0SwGwDgfIcOHVK7du302Wef6aKLLlK/fv1Uq1Yt/fDDD1q3bp2mTZum9PR0paenB7vVam3q1KkaN26cLrzwwmC3AgAAzoD85AzkJ6B6YPEKwBk98sgj+uyzzzRw4EA99dRTcrlcXsd37dql4uLiIHUXOpKTk5WcnBzsNgAAQDmQn5yB/ARUD7xtEMAZZWVlSZLuuOMOK3hJUsOGDdWkSROrnpubq5EjR+qiiy6S2+3W+eefr169eunzzz+3xpbtFVBYWKgRI0aoXr16crvdat68uV555RVr7Pz58z3ndrlccrlc6tixo9e4Xbt2aeDAgapfv77cbreSk5M1YMAAffvtt9b5y26/f/9+ZWZm6vzzz1dMTIyuvPJKrVixwufzcujQIU2ePFnNmzdXjRo1lJiYqEsvvVQTJ05USUnJWfdyKr4u9V+xYoVcLpfuvfdebdiwQV26dFF8fLwSExN14403nvJtAW+88YZatWqlmJgYXXDBBRo0aJAOHjx4ynMfPXpUM2fOVMuWLRUbG6v4+Hi1b99eb775pte4adOmyeVyaciQIdZ9lB0bOnRouR8zAABVFflphc/nhfxEfgLOhssYY4LdBABn69+/vxYsWKDFixfrT3/6U7lus3PnTnXs2FE5OTnq2rWrmjVrptzcXL366qtyuVz68MMP1bp1a8/4Bg0aqKSkRGlpaTp48KB+//vf6+eff9aiRYt0+PBhvffee+rataukE69kzps3T1u2bNGIESOUlJTkuY8BAwZIktauXatu3bqpqKhI3bt3V0ZGhnbv3q0lS5aoZs2aysrKUqNGjTznd7lc+t3vfqeioiIlJiaqffv2ys3N1eLFixUeHq6NGzfqkksu8YzPzc1Vhw4d9NVXX6lFixbq3LmzSktL9dVXX+nDDz9Ubm6up6+K9nIqAwYM0Pz587Vr1y7PpqArVqxQp06ddN111+mjjz5Sp06d1LRpU23evFnLly9Xenq6Pv/8c0VHR3vu57nnnlNmZqYSEhJ00003KSkpSW+//bZiYmK0b98+RUVFeYW24uJiXXvttVqxYoVatGih9u3bq6SkRO+8846ys7P12GOPafjw4ZKk0tJSdenSRcuXL9eSJUt0ww03SJLWrVundu3aKSMjQxs2bFBMTEy5fo4AAKiqyE/kJ/ITUIkMAJzBG2+8YSSZ+Ph4M3r0aLN06VLzww8/nPY2V111lQkPDzfvvfeeV33btm0mPj7eNGvWzKuelpZmJJmePXua4uJiT/2DDz4wkky3bt28xmdmZhpJZteuXda5jx49aho0aGDi4+PNpk2bvI6tXr3ahIeHm+7du3vVJRlJZtiwYeb48eOe+jPPPGMkmdtvv91rfK9evYwkM2HCBOv833//vSkpKTnrXk7F12P+6KOPPL0vWrTIa3z//v2NJLNw4UJPLT8/3yQkJJjY2Fizbds2T/3o0aPm6quvNpJMWlqa1/1MmDDBSDITJ040paWlnnpBQYG5/PLLTVRUlNm7d6+nnpOTY2rVqmVq1qxpcnJyTEFBgUlPTzdut9ts2bKlXI8VAICqjvxEfiI/AZWHxSsA5fLwww+buLg4zx96SSY9Pd3ccccdZvv27V5jN23aZCSZW2+91ed9jRo1ykgyW7du9dTKwtc333xjjU9LSzM1a9b0qp0ufL322mtGkrnvvvt8nv9//ud/TFhYmMnPz/fUJJnY2Fhz6NAhr7ElJSUmIiLCtGzZ0lPbt2+fcblcJj093Rw9etTnOc6ll1M5Xfi6+uqrrfFlx0aNGuWpzZ8/30gyf/3rX63xq1evtsLX8ePHzXnnnWfS09O9gleZN99800gyjz32mFf99ddfN5JMx44dTb9+/Ywk889//vOMjxEAgOqE/ER+Ij8BlYMN2wGUy6hRozRo0CC99957+uSTT7RhwwatXbtW//rXv/Tvf/9bixcvVo8ePSRJn376qSRp//79uvfee637+uqrrzz/e/Kl5ElJSWrYsKE1PiUlxbNvRHmUnX/btm0+z//999+rtLRU27dv1+WXX+6pN27cWHFxcV5jIyIidMEFFygvL89T27Bhg4wx6tSpkyIjI/3SS0VddtllVi0lJUWSvHrfsmWLJKl9+/bW+DZt2igiwvvPwrZt23Tw4EHVq1dPkydPtm5z4MABSb/MaZmePXtqyJAhmjNnjiTpuuuu09/+9rcKPCIAAKo+8lOep0Z++gX5Cag4Fq8AlFt8fLx69+6t3r17S5Ly8/M1YcIEPfHEE7rtttu0d+9eRUVF6aeffpIkvfPOO3rnnXdOeX9FRUVe3ycmJvocFxERodLS0nL3WXb+F1544bTjfn3+hISEU57/+PHjnu/z8/MlqVwfuXy2vVSUr97LgpSv3uvUqWONDw8PV61atbxqZf1/8cUX+uKLL055fl/933jjjZ7wVbanAwAAoYb8dAL5yUZ+AsqPTxsEcNYSExP1+OOPKy0tTT/88IO2bt0q6Zcg8Nhjj8mceHuyz/8yMzP90lfZ+d96663Tnr9Dhw5ndf9lG4nu3bs36L1UVFnAzc3NtY4dP35cP/74o1etrP9evXqdtv9nn33W63Z5eXkaNGiQYmNjFR0drb/+9a86dOiQnx4VAABVB/mJ/ER+AiqOxSsA58Tlcik2NtarVvYpOBW5VL2iwsPDJXm/Khao819++eUKCwvTRx99ZH2kc6B7qajf/e53kqTVq1dbx7KysnTs2DGvWtOmTZWQkKANGzac8bGebPDgwdqzZ4/++c9/6qGHHtLOnTt1xx13nFvzAABUE+Qn8pMv5Cfg1Fi8AnBGTz75pNavX+/z2Ouvv64vv/xSSUlJnv0XrrjiCrVu3VoLFy7U4sWLrduUlpZq5cqV59RTzZo1JUnZ2dnWsZ49e6p+/fqaOXOmVq1aZR0vKSnRxx9/fNbnvuCCC9SrVy/t3LnT5z4Gubm5nhDj714qqmfPnkpISNDcuXO1fft2rz7uvvtua3xERISGDh2qb7/9VnfeeafPAPb55597vRL573//Wy+//LJ69+6t2267TcOHD1f37t31/PPP68UXX/TPAwMAwGHIT97IT97IT0DFsOcVgDN69913NWTIEF100UVq27at6tWrp6KiIm3evFmrV69WWFiYnnjiCbndbs9tFi5cqE6dOqlPnz565JFH1LJlS8XExGjPnj3KysrSgQMHdOTIkbPuqXPnzpoxY4YGDx6sXr16KTY2Vmlpaerfv7/cbrdeeeUV/eEPf1CHDh3UuXNnNWvWTC6XS99++61Wr16tWrVqWZtkVsQTTzyhzz//XPfff7/+85//qHPnzjLGaPv27Vq2bJn279+vpKSkgPRSEYmJiXr00Uc1YMAAtWrVSn369FFiYqLefvttxcTEKDk52brN5MmTtWnTJj366KN65513dPXVV6tOnTrau3evtm7dqi1btigrK0t16tTR9u3bNWLECKWmpuqpp57y3MfcuXPVvHlzDR06VG3atPG5sSwAANUJ+clGfiI/AWetcj60EEB19tVXX5kHH3zQdOnSxTRs2NBER0eb6Ohok56ebjIzM82GDRt83u6nn34yd999t7nkkktMTEyMiYuLMxkZGaZv377mtdde8xqblpbm9RHDJ+vQoYPx9c/Vgw8+aDIyMkxkZKSRZDp06OB1PCcnx4wYMcJkZGQYt9ttEhISTNOmTc3AgQPNhx9+6DXW1+3P1Ft+fr6ZOHGiadKkiXG73SYxMdG0aNHC3HPPPdZHQFekl1M53Uc9T5o0yRq/a9cuI8lkZmZax5YsWWIuu+wy43a7TZ06dczAgQPNTz/9dMrHeuzYMfPkk0+atm3bmoSEBON2u039+vXNtddea2bPnm0KCwtNcXGxadmypQkLCzMrV6607mPZsmXG5XKZK6+80pSUlJTrMQMAUFWRn8hP5Ceg8riMMSY4y2YAAAAAAADA6bHnFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADH+v/zMeuZub9beAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1400x1000 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig, ax_arr = plt.subplots(nrows=1, ncols=2, figsize=(7, 5), dpi=200)\n",
     "\n",
@@ -613,11 +411,11 @@
     "label_fontsize = 7\n",
     "title_list = [\"True text segmentation\", \"Predicted text segmentation\"]\n",
     "\n",
-    "for (ax, title, bkps) in zip(ax_arr, title_list, [TRUE_BKPS, predicted_bkps]):\n",
+    "for ax, title, bkps in zip(ax_arr, title_list, [TRUE_BKPS, predicted_bkps]):\n",
     "    # plot gram matrix\n",
     "    ax.imshow(algo.cost.gram.toarray(), cmap=cm.plasma, norm=LogNorm())\n",
     "    # add text segmentation\n",
-    "    for (start, end) in rpt.utils.pairwise([0] + bkps):\n",
+    "    for start, end in rpt.utils.pairwise([0] + bkps):\n",
     "        draw_square_on_ax(start=start, end=end, ax=ax)\n",
     "    # add labels and title\n",
     "    ax.set_title(title, fontsize=title_fontsize)\n",
@@ -652,142 +450,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-28T12:51:15.033923Z",
-     "iopub.status.busy": "2023-03-28T12:51:15.033812Z",
-     "iopub.status.idle": "2023-03-28T12:51:15.036376Z",
-     "shell.execute_reply": "2023-03-28T12:51:15.036143Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 1: The Sane Society is an ambitious work .\n",
-      " 2: Its scope is as broad as the question : What does it mean to live in modern society ? ?\n",
-      " 3: A work so broad , even when it is directed by a leading idea and informed by a moral vision , must necessarily `` fail '' .\n",
-      " 4: Even a hasty reader will easily find in it numerous blind spots , errors of fact and argument , important exclusions , areas of ignorance and prejudice , undue emphases on trivia , examples of broad positions supported by flimsy evidence , and the like .\n",
-      " 5: Such books are easy prey for critics .\n",
-      " 6: Nor need the critic be captious .\n",
-      " 7: A careful and orderly man , who values precision and a kind of tough intellectual responsibility , might easily be put off by such a book .\n",
-      " 8: It is a simple matter , for one so disposed , to take a work like The Sane Society and shred it into odds and ends .\n",
-      " 9: The thing can be made to look like the cluttered attic of a large and vigorous family -- a motley jumble of discarded objects , some outworn and some that were never useful , some once whole and bright but now chipped and tarnished , some odd pieces whose history no one remembers , here and there a gem , everything fascinating because it suggests some part of the human condition -- the whole adding up to nothing more than a glimpse into the disorderly history of the makers and users .\n",
-      "10: That could be easily done , but there is little reason in it .\n",
-      "11: It would come down to saying that Fromm paints with a broad brush , and that , after all , is not a conclusion one must work toward but an impression he has from the outset .\n",
-      "\n",
-      "12: the effect of the digitalis glycosides is inhibited by a high concentration of potassium in the incubation medium and is enhanced by the absence of potassium ( Wolff , 1960 ) .\n",
-      "13: B. Organification of iodine The precise mechanism for organification of iodine in the thyroid is not as yet completely understood .\n",
-      "14: However , the formation of organically bound iodine , mainly mono-iodotyrosine , can be accomplished in cell-free systems .\n",
-      "15: In the absence of additions to the homogenate , the product formed is an iodinated particulate protein ( Fawcett and Kirkwood , 1953 ; ; Taurog , Potter and Chaikoff , 1955 ; ; Taurog , Potter , Tong , and Chaikoff , 1956 ; ; Serif and Kirkwood , 1958 ; ; De Groot and Carvalho , 1960 ) .\n",
-      "16: This iodoprotein does not appear to be the same as what is normally present in the thyroid , and there is no evidence so far that thyroglobulin can be iodinated in vitro by cell-free systems .\n",
-      "17: In addition , the iodoamino acid formed in largest quantity in the intact thyroid is di-iodotyrosine .\n",
-      "18: If tyrosine and a system generating hydrogen peroxide are added to a cell-free homogenate of the thyroid , large quantities of free mono-iodotyrosine can be formed ( Alexander , 1959 ) .\n",
-      "19: It is not clear whether this system bears any resemblance to the in vivo iodinating mechanism , and a system generating peroxide has not been identified in thyroid tissue .\n",
-      "20: On chemical grounds it seems most likely that iodide is first converted to Afj and then to Afj as the active iodinating species .\n",
-      "\n",
-      "21: the statement empirical , for goodness was not a quality like red or squeaky that could be seen or heard .\n",
-      "22: What were they to do , then , with these awkward judgments of value ? ?\n",
-      "23: To find a place for them in their theory of knowledge would require them to revise the theory radically , and yet that theory was what they regarded as their most important discovery .\n",
-      "24: It appeared that the theory could be saved in one way only .\n",
-      "25: If it could be shown that judgments of good and bad were not judgments at all , that they asserted nothing true or false , but merely expressed emotions like `` Hurrah '' or `` Fiddlesticks '' , then these wayward judgments would cease from troubling and weary heads could be at rest .\n",
-      "26: This is the course the positivists took .\n",
-      "27: They explained value judgments by explaining them away .\n",
-      "28: Now I do not think their view will do .\n",
-      "29: But before discussing it , I should like to record one vote of thanks to them for the clarity with which they have stated their case .\n",
-      "30: It has been said of John Stuart Mill that he wrote so clearly that he could be found out .\n",
-      "\n",
-      "31: Greer Garson , world-famous star of stage , screen and television , will be honored for the high standard in tasteful sophisticated fashion with which she has created a high standard in her profession .\n",
-      "32: As a Neiman-Marcus award winner the titian-haired Miss Garson is a personification of the individual look so important to fashion this season .\n",
-      "33: She will receive the 1961 `` Oscar '' at the 24th annual Neiman-Marcus Exposition , Tuesday and Wednesday in the Grand Ballroom of the Sheraton-Dallas Hotel .\n",
-      "34: The only woman recipient , Miss Garson will receive the award with Ferdinando Sarmi , creator of chic , beautiful women 's fashions ; ; Harry Rolnick , president of the Byer-Rolnick Hat Corporation and designer of men 's hats ; ; Sydney Wragge , creator of sophisticated casuals for women and Roger Vivier , designer of Christian Dior shoes Paris , France , whose squared toes and lowered heels have revolutionized the shoe industry .\n",
-      "35: The silver and ebony plaques will be presented at noon luncheons by Stanley Marcus , president of Neiman-Marcus , Beneficiary of the proceeds from the two showings will be the Dallas Society for Crippled Children Cerebral Palsy Treatment Center .\n",
-      "36: The attractive Greer Garson , who loves beautiful clothes and selects them as carefully as she does her professional roles , prefers timeless classical designs .\n",
-      "37: Occasionally she deserts the simple and elegant for a fun piece simply because `` It 's unlike me '' .\n",
-      "38: In private life , Miss Garson is Mrs. E.E. Fogelson and on the go most of the time commuting from Dallas , where they maintain an apartment , to their California home in Los Angeles ' suburban Bel-Air to their ranch in Pecos , New Mexico .\n",
-      "39: Therefore , her wardrobe is largely mobile , to be packed at a moment 's notice and to shake out without a wrinkle .\n",
-      "40: Her creations in fashion are from many designers because she does n't want a complete wardrobe from any one designer any more than she wants `` all of her pictures by one painter '' .\n",
-      "\n",
-      "41: Wage-price policies of industry are the result of a complex of forces -- no single explanation has been found which applies to all cases .\n",
-      "42: The purpose of this paper is to analyze one possible force which has not been treated in the literature , but which we believe makes a significant contribution to explaining the wage-price behavior of a few very important industries .\n",
-      "43: While there may be several such industries to which the model of this paper is applicable , the authors make particular claim of relevance to the explanation of the course of wages and prices in the steel industry of the United States since World War 2 .\n",
-      "44: Indeed , the apparent stiffening of the industry 's attitude in the recent steel strike has a direct explanation in terms of the model here presented .\n",
-      "45: The model of this paper considers an industry which is not characterized by vigorous price competition , but which is so basic that its wage-price policies are held in check by continuous critical public scrutiny .\n",
-      "46: Where the industry 's product price has been kept below the `` profit-maximizing '' and `` entry-limiting '' prices due to fears of public reaction , the profit seeking producers have an interest in offering little real resistance to wage demands .\n",
-      "47: The contribution of this paper is a demonstration of this proposition , and an exploration of some of its implications .\n",
-      "48: In order to focus clearly upon the operation of this one force , which we may call the effect of `` public-limit pricing '' on `` key '' wage bargains , we deliberately simplify the model by abstracting from other forces , such as union power , which may be relevant in an actual situation .\n",
-      "49: For expository purposes , this is best treated as a model which spells out the conditions under which an important industry affected with the public interest would find it profitable to raise wages even in the absence of union pressures for higher wages .\n",
-      "\n",
-      "50: The vast Central Valley of California is one of the most productive agricultural areas in the world .\n",
-      "51: During the summer of 1960 , it became the setting for a bitter and basic labor-management struggle .\n",
-      "52: The contestants in this economic struggle are the Agricultural Workers Organizing Committee ( AWOC ) of the AFL-CIO and the agricultural employers of the State .\n",
-      "53: By virtue of the legal responsibilities of the Department of Employment in the farm placement program , we necessarily found ourselves in the middle between these two forces .\n",
-      "54: It is not a pleasant or easy position , but one we have endeavored to maintain .\n",
-      "55: We have sought to be strictly neutral as between the parties , but at the same time we have been required frequently to rule on specific issues or situations as they arose .\n",
-      "56: Inevitably , one side was pleased and the other displeased , regardless of how we ruled .\n",
-      "57: Often the displeased parties interpreted our decision as implying favoritism toward the other .\n",
-      "58: We have consoled ourselves with the thought that this is a normal human reaction and is one of the consequences of any decision in an adversary proceeding .\n",
-      "59: It is disconcerting , nevertheless , to read in a labor weekly , `` Perluss knuckles down to growers '' , and then to be confronted with a growers ' publication which states , `` Perluss recognizes obviously phony and trumped-up strikes as bona fide '' .\n",
-      "\n",
-      "60: Rookie Ron Nischwitz continued his pinpoint pitching Monday night as the Bears made it two straight over Indianapolis , 5-3 .\n",
-      "61: The husky 6-3 , 205-pound lefthander , was in command all the way before an on-the-scene audience of only 949 and countless of television viewers in the Denver area .\n",
-      "62: It was Nischwitz ' third straight victory of the new season and ran the Grizzlies ' winning streak to four straight .\n",
-      "63: They now lead Louisville by a full game on top of the American Association pack .\n",
-      "64: Nischwitz fanned six and walked only Charley Hinton in the third inning .\n",
-      "65: He has given only the one pass in his 27 innings , an unusual characteristic for a southpaw .\n",
-      "66: The Bears took the lead in the first inning , as they did in Sunday 's opener , and never lagged .\n",
-      "67: Dick McAuliffe cracked the first of his two doubles against Lefty Don Rudolph to open the Bear 's attack .\n",
-      "68: After Al Paschal gruonded out , Jay Cooke walked and Jim McDaniel singled home McAuliffe .\n",
-      "69: Alusik then moved Cooke across with a line drive to left .\n",
-      "\n",
-      "70: Unemployed older workers who have no expectation of securing employment in the occupation in which they are skilled should be able to secure counseling and retraining in an occupation with a future .\n",
-      "71: Some vocational training schools provide such training , but the current need exceeds the facilities .\n",
-      "72: Current programs The present Federal program of vocational education began in 1917 with the passage of the Smith-Hughes Act , which provided a continuing annual appropriation of $ 7 million to support , on a matching basis , state-administered programs of vocational education in agriculture , trades , industrial skills and home economics .\n",
-      "73: Since 1917 some thirteen supplementary and related acts have extended this Federal program .\n",
-      "74: The George-Barden Act of 1946 raised the previous increases in annual authorizations to $ 29 million in addition to the $ 7 million under the Smith Act .\n",
-      "75: The Health Amendment Act of 1956 added $ 5 million for practical nurse training .\n",
-      "76: The latest major change in this program was introduced by the National Defense Education Act of 1958 , Title 8 , of which amended the George-Barden Act .\n",
-      "77: Annual authorizations of $ 15 million were added for area vocational education programs that meet national defense needs for highly skilled technicians .\n",
-      "78: The Federal program of vocational education merely provides financial aid to encourage the establishment of vocational education programs in public schools .\n",
-      "79: The initiative , administration and control remain primarily with the local school districts .\n",
-      "80: Even the states remain primarily in an assisting role , providing leadership and teacher training .\n",
-      "\n",
-      "81: briefly , the topping configuration must be examined for its inferences .\n",
-      "82: Then the fact that the lower channel line was pierced had further forecasting significance .\n",
-      "83: And then the application of the count rules to the width ( horizontally ) of the configuration gives us an intial estimate of the probable depth of the decline .\n",
-      "84: The very idea of there being `` count rules '' implies that there is some sort of proportion to be expected between the amount of congestive activity and the extent of the breakaway ( run up or run down ) movement .\n",
-      "85: This expectation is what really `` sold '' point and figure .\n",
-      "86: But there is no positive and consistently demonstrable relationship in the strictest sense .\n",
-      "87: Experience will show that only the vaguest generalities apply , and in fine , these merely dwell upon a relationship between the durations and intensities of events .\n",
-      "88: After all , too much does not happen too suddenly , nor does very little take long .\n",
-      "89: The advantages and disadvantages of these two types of charting , bar charting and point and figure charting , remain the subject of fairly good-natured litigation among their respective professional advocates , with both methods enjoying in common , one irrevocable merit .\n",
-      "90: They are both trend-following methods .\n",
-      "\n",
-      "91: Miami , Fla. , March 17 -- The Orioles tonight retained the distinction of being the only winless team among the eighteen Major-League clubs as they dropped their sixth straight spring exhibition decision , this one to the Kansas City Athletics by a score of 5 to 3 .\n",
-      "92: Indications as late as the top of the sixth were that the Birds were to end their victory draught as they coasted along with a 3-to-o advantage .\n",
-      "93: Siebern hits homer Over the first five frames , Jack Fisher , the big righthander who figures to be in the middle of Oriole plans for a drive on the 1961 American League pennant , held the A 's scoreless while yielding three scattered hits .\n",
-      "94: Then Dick Hyde , submarine-ball hurler , entered the contest and only five batters needed to face him before there existed a 3-to-3 deadlock .\n",
-      "95: A two-run homer by Norm Siebern and a solo blast by Bill Tuttle tied the game , and single runs in the eighth and ninth gave the Athletics their fifth victory in eight starts .\n",
-      "96: House throws wild With one down in the eighth , Marv Throneberry drew a walk and stole second as Hyde fanned Tuttle .\n",
-      "97: Catcher Frank House 's throw in an effort to nab Throneberry was wide and in the dirt .\n",
-      "98: Then Heywood Sullivan , Kansas City catcher , singled up the middle and Throneberry was across with what proved to be the winning run .\n",
-      "99: Rookie southpaw George Stepanovich relieved Hyde at the start of the ninth and gave up the A 's fifth tally on a walk to second baseman Dick Howser , a wild pitch , and Frank Cipriani 's single under Shortstop Jerry Adair 's glove into center .\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "for (start, end) in rpt.utils.pairwise([0] + TRUE_BKPS):\n",
+    "for start, end in rpt.utils.pairwise([0] + TRUE_BKPS):\n",
     "    excerpt = original_text[start:end]\n",
-    "    for (n_line, sentence) in enumerate(excerpt, start=start + 1):\n",
+    "    for n_line, sentence in enumerate(excerpt, start=start + 1):\n",
     "        sentence = sentence.strip(\"\\n\")\n",
     "        print(f\"{n_line:>2}: {sentence}\")\n",
     "    print()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/examples/text-segmentation.ipynb
+++ b/docs/examples/text-segmentation.ipynb
@@ -33,8 +33,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:13.117941Z",
+     "iopub.status.busy": "2023-03-28T12:51:13.117616Z",
+     "iopub.status.idle": "2023-03-28T12:51:13.932607Z",
+     "shell.execute_reply": "2023-03-28T12:51:13.932247Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -55,9 +62,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:13.934081Z",
+     "iopub.status.busy": "2023-03-28T12:51:13.933930Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.163280Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.162615Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package stopwords to\n",
+      "[nltk_data]     /Users/oboulant/nltk_data...\n",
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
+     ]
+    }
+   ],
    "source": [
     "nltk.download(\"stopwords\")\n",
     "STOPWORD_SET = set(\n",
@@ -75,8 +99,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.196707Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.196549Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.199491Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.199164Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def preprocess(list_of_sentences: list) -> list:\n",
@@ -94,8 +125,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.200948Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.200820Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.203493Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.203218Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def draw_square_on_ax(start, end, ax, linewidth=0.8):\n",
@@ -138,9 +176,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.204919Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.204796Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.207578Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.207287Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 99 sentences, from 10 documents.\n"
+     ]
+    }
+   ],
    "source": [
     "# Loading the text\n",
     "filepath = Path(\"../data/text-segmentation-data.txt\")\n",
@@ -161,9 +214,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.208898Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.208780Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.211053Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.210778Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10: That could be easily done , but there is little reason in it .\n",
+      "11: It would come down to saying that Fromm paints with a broad brush , and that , after all , is not a conclusion one must work toward but an impression he has from the outset .\n",
+      "12: the effect of the digitalis glycosides is inhibited by a high concentration of potassium in the incubation medium and is enhanced by the absence of potassium ( Wolff , 1960 ) .\n",
+      "13: B. Organification of iodine The precise mechanism for organification of iodine in the thyroid is not as yet completely understood .\n",
+      "14: However , the formation of organically bound iodine , mainly mono-iodotyrosine , can be accomplished in cell-free systems .\n"
+     ]
+    }
+   ],
    "source": [
     "# print 5 sentences from the original text\n",
     "start, end = 9, 14\n",
@@ -188,9 +260,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.212348Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.212236Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.231142Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.230888Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original sentence:\n",
+      "\tThen Heywood Sullivan , Kansas City catcher , singled up the middle and Throneberry was across with what proved to be the winning run .\n",
+      "\n",
+      "Transformed:\n",
+      "\theywood sullivan kansa citi catcher singl middl throneberri across prove win run\n"
+     ]
+    }
+   ],
    "source": [
     "# transform text\n",
     "transformed_text = preprocess(original_text)\n",
@@ -205,15 +296,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.232248Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.232166Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.236153Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.235917Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 842 different words in the corpus, e.g. ['acid' 'across' 'act' 'activ' 'actual' 'ad' 'adair' 'addit' 'administ'\n",
+      " 'administr'].\n"
+     ]
+    }
+   ],
    "source": [
     "# Once the text is preprocessed, each sentence is transformed into a vector of word counts.\n",
     "vectorizer = CountVectorizer(analyzer=\"word\")\n",
     "vectorized_text = vectorizer.fit_transform(transformed_text)\n",
     "\n",
-    "msg = f\"There are {len(vectorizer.get_feature_names())} different words in the corpus, e.g. {vectorizer.get_feature_names()[20:30]}.\"\n",
+    "msg = f\"There are {len(vectorizer.get_feature_names_out())} different words in the corpus, e.g. {vectorizer.get_feature_names_out()[20:30]}.\"\n",
     "print(msg)"
    ]
   },
@@ -266,8 +373,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.237418Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.237339Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.240092Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.239864Z"
+    }
+   },
    "outputs": [],
    "source": [
     "class CosineCost(BaseCost):\n",
@@ -317,9 +431,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.241192Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.241111Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.501297Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.500970Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True change points are\t\t[11, 20, 30, 40, 49, 59, 69, 80, 90, 99].\n",
+      "Detected change points are\t[12, 19, 30, 40, 49, 59, 70, 78, 94, 99].\n"
+     ]
+    }
+   ],
    "source": [
     "n_bkps = 9  # there are 9 change points (10 text segments)\n",
     "\n",
@@ -356,9 +486,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.502717Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.502627Z",
+     "iopub.status.idle": "2023-03-28T12:51:14.505701Z",
+     "shell.execute_reply": "2023-03-28T12:51:14.505416Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paragraph n°01\n",
+      "(true)\t01 02 03 04 05 06 07 08 09 10 11   \n",
+      "(pred)\t01 02 03 04 05 06 07 08 09 10 11 12\n",
+      "\n",
+      "Paragraph n°02\n",
+      "(true)\t12 13 14 15 16 17 18 19 20\n",
+      "(pred)\t   13 14 15 16 17 18 19   \n",
+      "\n",
+      "Paragraph n°03\n",
+      "(true)\t   21 22 23 24 25 26 27 28 29 30\n",
+      "(pred)\t20 21 22 23 24 25 26 27 28 29 30\n",
+      "\n",
+      "Paragraph n°04\n",
+      "(true)\t31 32 33 34 35 36 37 38 39 40\n",
+      "(pred)\t31 32 33 34 35 36 37 38 39 40\n",
+      "\n",
+      "Paragraph n°05\n",
+      "(true)\t41 42 43 44 45 46 47 48 49\n",
+      "(pred)\t41 42 43 44 45 46 47 48 49\n",
+      "\n",
+      "Paragraph n°06\n",
+      "(true)\t50 51 52 53 54 55 56 57 58 59\n",
+      "(pred)\t50 51 52 53 54 55 56 57 58 59\n",
+      "\n",
+      "Paragraph n°07\n",
+      "(true)\t60 61 62 63 64 65 66 67 68 69   \n",
+      "(pred)\t60 61 62 63 64 65 66 67 68 69 70\n",
+      "\n",
+      "Paragraph n°08\n",
+      "(true)\t70 71 72 73 74 75 76 77 78 79 80\n",
+      "(pred)\t   71 72 73 74 75 76 77 78      \n",
+      "\n",
+      "Paragraph n°09\n",
+      "(true)\t      81 82 83 84 85 86 87 88 89 90            \n",
+      "(pred)\t79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94\n",
+      "\n",
+      "Paragraph n°10\n",
+      "(true)\t91 92 93 94 95 96 97 98 99\n",
+      "(pred)\t            95 96 97 98 99\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "true_segment_list = rpt.utils.pairwise([0] + TRUE_BKPS)\n",
     "predicted_segment_list = rpt.utils.pairwise([0] + predicted_bkps)\n",
@@ -400,9 +584,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:14.506909Z",
+     "iopub.status.busy": "2023-03-28T12:51:14.506819Z",
+     "iopub.status.idle": "2023-03-28T12:51:15.032564Z",
+     "shell.execute_reply": "2023-03-28T12:51:15.032270Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABK8AAAKACAYAAABaLls9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAB7CAAAewgFu0HU+AADAVUlEQVR4nOzdd3gUZdfH8d+SRhJCQIoECU2KDUGkWxAUsCMqAlJFUbHCI4L4gIhIFcSCiIgURQQFpdiwUEWQrvBY6JpgKAokEJJAknn/4M2S5Z4km2Q3uxu+n+vKde2euWfmbD+5d/aMw7IsSwAAAAAAAIAfKuHrBAAAAAAAAICcMHkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAA5MOLL74oh8Mhh8Ph61QAwO+sWLHC+R65YsUKY3mvXr3kcDhUvXr1Is/NV2644QY5HA7dcMMNvk4FgKR9+/Y536dmzpzp63TgJiavUGxkfxMqzB8AAIC3ZZ/kOfcvIiJC1apV01133aU5c+YoPT3d1+kCAOBTTF4BxVygfcNZvXp1ORwO9erVy9epwIfy+ube02bOnOnc3759+7y+PwDITUpKiv766y8tWrRIXbt2VYsWLXTgwAFfp+X3Aq3mcVdRfyYWFkcoI0tR1/VZz7sXX3yxSPaHohXs6wQAT7nooou0bdu2HJfXq1dPktSoUSPNmDGjqNICUMy8+OKLFEUAPKpv37567LHHnNdPnDihjRs3asKECdq3b582bNig9u3ba926dQE/ITBz5kx+pgPAp6pXry7LsnydBvKJySsUGyEhIbriiivyHBcZGenWOAAAgKJQsWJFozZp1qyZunbtqiZNmmjXrl1av369Pv/8c91xxx0+yhIAAN/hZ4MAAACAHypbtqwGDx7svP7111/7MBsAAHyHyStA5llgdu7cqSeeeEK1a9dWRESESx8cd3vj5OcsFgsXLlTHjh1VtWpVlSxZUmXKlFGjRo00fPhwHT16tEC3KavfwKxZsyRJf/75p9sN6lNTUzVp0iTdeOONqlSpkkJDQ1WxYkXddNNNeu+992wbx/7www8KCgqSw+HQbbfdlmNeSUlJqlGjhhwOhypWrKiDBw9KOvsY/Pnnn5KkWbNmGbkW5Cw9qampeuONN3TDDTeoQoUKCgkJ0QUXXKC6devqlltu0auvvprr45iRkaFZs2bp9ttvV+XKlRUWFqZy5crp2muv1auvvqqUlJQ8c9i+fbt69OihKlWqqGTJkqpataq6deumzZs3S8q9R4fd8+jTTz9V27ZtVbFiRUVGRqp+/fp68803dfr0aed6lmVpzpw5uuGGG1SxYkVFRESoYcOGmjJliluHSScmJmr06NG65pprVKFCBYWGhiomJkZ33HGH5s+fn+s2zu03sGHDBnXp0kVVqlRRWFiYLrroInXv3l2//fZbjre3VatWzlirVq2M58K5r6nt27fr5ZdfVrt27Zz7KVWqlGrXrq2ePXtq3bp1trlm9RF54IEHnLGs52f2v+w9Rtzt5bFv3z71799fl19+uaKiohQREaHatWvrkUceyfUnzoW9DwEUL02aNHFezvqMlMw+SJmZmZo+fbpatWqlCy+8UCVKlLDtM7N582Y9+uijqlu3rkqVKqXIyEjVrVtXffv21Y4dO/LMJyUlRaNGjVL9+vUVGRmpcuXK6ZprrtG7776rzMzMPNd3ty/V8ePHNWHCBLVu3dpZi5QuXVpXXXWVnnzySa1Zs8Y5tqhrnnOtW7dOHTt2VKVKlVSyZEnVqFFDDz/8sP744488181NQT8Tsyxfvlw9e/ZUzZo1FRERodKlS6tevXp69tln9ffffxvj09LSdOWVV8rhcCgqKkp79uzJMbf//Oc/zv1ntePIqpGHDx/uHGf3OBSkt+SyZcvUpUsX1ahRQ+Hh4c6TGjRr1kwDBgzQsmXLcl2/sM/7kydPasSIEbryyiudz/trr71W06dPl2VZefYlO/d/jV27dunRRx9VzZo1FR4erurVq+vBBx90eY1LZ+qbBx54QDVr1lTJkiUVGxurvn376tChQ27dbwX9H+Pc1+mxY8f0wgsv6PLLL1dkZKTKlCmj66+/Xh9++KHt+gWp648ePaoZM2aoW7duuuyyy1SqVCmFhoaqUqVKateunaZOnapTp07Z7i+rt1aW4cOHG/vL/n7o7v9pp06d0uTJk9WqVStnPVypUiXdeuutmj17dq7veYW9D2HDAs4TkixJVsuWLY1lLVu2dC5buHChFRkZ6Ryf9bd3717LsixrxowZRszO3r17neNmzJhhO+bIkSNW69atjX1l/6tYsaK1du3afN/eYcOG5brdrL9zbd261apWrVqu6zRu3Ng6cOCAse7zzz/vHPPWW2/Z5tWtWzfnmMWLFzvjWY9Bbn92j11u/v77b+uyyy7Lc7vPPPOM7fp//vmnVb9+/VzXrVWrlvXHH3/kmMMHH3xghYSE2K4bEhJizZw50+rZs6clyapWrZqx/rnPo759++aYy913322lp6dbqamp1r333pvjuD59+uR6v3333XdWuXLlcr3dt956q3X8+HHb9bPGDBs2zHrrrbes4OBg221ERERYK1euzPH25vaX/TW1fPlyt9Z57rnnjFzdXXf58uXOdbK/tnIya9YsKywsLMftBQUFWaNGjcpx/cLchwACQ/b3n2HDhuU47vfff3eOu/nmm23X/+qrr6ybbrrJeI/o2bOnc3xGRobVv39/y+Fw5PjeFBwcbL3zzjs55pKQkGBdeumlOa7frl07a+nSpbbvnVly+8zL8u2331rly5fP8705iy9qniyvvvqqVaJECdt1IyMjrS+++MKlzsyPgnwmWpZlpaSkWJ07d851ncjISJc6LMsvv/zi/Pxq3ry5lZ6eboz59ttvnc+je+65xxnPXiPn9pdb/WynX79+eW6zXLlytut64nkfFxdn1a5dO8f1b7/9duubb77J9Xmf/Tnw7bffWlFRUbbbqlixovXbb79ZlmVZc+bMsUJDQ23HVatWzdq/f3+OORf2f4zsr9Pff//dql69eo7befzxx3O8vbn9nft6yOu1KMm66qqrrISEBGN/7qyb/f3Qnf/T9u7da11yySW5bvPaa6+1/v33X6/chzAxeYXzRk5vlJZ19g22Ro0aVqlSpawKFSpYY8aMsdasWWOtW7fOevPNN63Dhw9bluW5yavU1FSrYcOGlnTmH9nu3btbH330kbVu3Tpr9erV1siRI50TCGXLlrX27duXr9t78OBBa9u2bVb79u0tSVblypWtbdu2GX/Z7dy504qOjrYkWaVLl7YGDx5sffbZZ9bGjRutpUuXWo8//rjzn+imTZtap06dcln/1KlTVqNGjSxJVnh4uPPDN8tHH33kvE8eeeQRl2V79uyxtm3bZlWuXNmSZLVv397Idc+ePfm6D+655x7n/rp162Z9+umn1rp166wNGzZYixcvtl544QWrfv36tpNX//zzjxUbG2tJssLCwqwnnnjC+uSTT6wNGzZYy5cvtwYPHmxFRERYkqyaNWtax44dM7axZs0aKygoyJLOTDIMGTLEWrVqlfXTTz9Zb731llWlShUrNDTUuuqqq5wfbufK/jxq2rSpJZ2ZOPr000+tTZs2WQsXLnTGJVnvvvuu9eSTT1qSrPvvv9/6/PPPrU2bNllz5851+QD+6quvbO+zH374wTnZduGFF1ovv/yytWTJEmvTpk3WkiVLXCYf7777btttZC1v1qyZVaJECat+/frW9OnTrQ0bNlirVq2y+vfv7yz0q1ataqWlpTnXPXXqlLVt2zZr+vTpzu1Mnz7deC4cPXrUuc63335rRUZGWvfdd581ZcoUa8WKFdbmzZutr7/+2powYYJLQTN9+nSXXE+cOGFt27bNevnll51jli5dauzvxIkTznXymrz6/PPPnUVyqVKlrGHDhlmrV6+21q5da02YMMHlH7LJkyd7/D4EEBjcnbz65JNPnON69+5tu/6VV15pSbLuvPNO5+fDl19+ac2dO9c5/rHHHnOOv/76663p06dbK1assNavX2+9++671uWXX+5cvmjRIiOP06dPW1dffbVzTNu2bZ01wqeffuqcPGvcuLFzTEEmr5YtW+asNYKCgqxevXpZn332mbVp0yZrzZo11rvvvmvdfffdVkhIiHMdX9Q8lmVZn376qfO2RkdHW6NGjbJ+/PFH68cff7Refvllq3Tp0laZMmWcEx/5nbwqyGdiZmamddtttznH33HHHdYHH3xgrVmzxlq7dq31+uuvW1WrVrUkWaGhodaGDRuM/U6cONG5/osvvuiy7N9//3XWapUrV7b++ecf57KjR49a27Ztc/mize5xsLsvc7JkyRKX5/nbb79trVixwtqyZYu1fPlya9KkSdZdd91lVa5c2Xb9wj7vT5065Xx9SbJuu+02a+HChdbGjRuthQsXWrfeeqtLjZbT8z7rf43atWtbZcuWtWJjY60333zT+umnn6zVq1db/fr1c9YO11xzjbV+/XorODjYuvTSS61p06ZZ69evt5YvX251797duZ9OnTrZ3mZP/I+R9TqtUKGCVbt2bSsqKsoaMmSItWLFCmvjxo3Wu+++a1WpUsWZy9dff+2yfkHq+ipVqlhNmza1RowYYX3++efWhg0brDVr1lizZ8+2br755lz/l/vjjz+sbdu2Ocf07dvX2F98fLxzfF7/px0/ftyqWbOmc8xdd91lLV682Nq4caP1ySefuEzOtWjRwnaSt7D3IUxMXuG84c7kVdYH8Z9//pnjdjw1eZV1lFKZMmWsjRs32m5j3759VkxMjHMioiDc+YYzS4sWLSzpzLcaWZN15/rqq6+c/zRPnTrVWP7HH384J3Wuuuoq5z/Vf/31l1WmTBlLklWnTh0rOTnZdvtZEw3Zvx0piJSUFOckTE5HVmWx+8bk/vvvd95vOU2abd682XmU3vPPP28sb9CggXPya926dcbygwcPunww5jV5Jcnq16+fMSY5Odl5v5UrV85yOBzWa6+9ZoxLSEhwftN35513GstPnTrl/Fbo5ptvzvExmjp1qjOfb775xliePd9bb73VdmIl+2TRp59+aizP/k+ZXRGY3eHDh10K93OlpaVZbdq0cd7HdgWGu69ry8p98urUqVPOQq1UqVLWli1bjDHZX9cRERG2rzVP3IcA/Js7k1enT5+2mjVr5hz3/vvv264vyRoyZEiO+8p+VMi0adNsx6SkpDiP1KhWrZp1+vRpl+WTJk1ybuPhhx+23Ubv3r1dcsrv5FVKSorzPTQiIiLX9/+//vorX9s+V2FrnrS0NGeu0dHR1q+//mqsv23bNqt06dK51qDuyM9nYtZndEhISI5fVB05csQ5aXPNNdcYyzMzM52fm8HBwS5H59x9992WJMvhcNjWAJbl3hHK7sqarKlWrVqOR3xbln0t54nn/WuvvZZrDWZZlvXEE0/k+bzP/r9G7dq1rUOHDhljBgwY4BxToUIFq0WLFra1WMeOHZ2Pjd12PPE/RtZrKev5vX37dmPMzp07rZIlS+ZYV1pW/ur6HTt25Lo8+yTud999Zzsmr/fULHn9n5b9sbB7b83MzLS6du3qHGP3ZaSn7kOcxeQVzhvuTl5lLwzteGLy6vjx485v+958881c9zd58mRnEZL96A93uVvIrVq1ypnvL7/8kuvY++67z5LOfNNg55133nFua+DAgVZGRobzPg4JCbH9li+Lpyav9u/f78zB7pu03Ozdu9d5xNSSJUtyHTtw4EBLkvGN37p165z7HzBgQI7rL1q0yO3Jq9jY2By/rXzhhRec45o1a5bj/nr06GFJZ75pO9f7779vSbJKlixpWwxl16RJkxwLnqw8SpYsaR08eNB2/aSkJOeh8P379zeW56dQd8fWrVud27Mr5Dw1eTVv3jznsjFjxuS4jdmzZzvHjRs3zljuifsQgH/LbfLqxIkT1ooVK6wbbrjB5TMiNTXVdv06derYTsxnyfrnPPtPvOz8+uuvzm2eOzGR9TP8Cy+8MMcvN44fP25VqFChwJNX2esHuy9h8lKUNc/HH3/s3Mb48eNzXH/s2LFFNnmVmZlpXXzxxZaU9xd3X375pXObdpMG+/fvdx6dc/HFF1vHjx+33nvvvTwncizLs5NXWZNoHTp0yPe6nnjeZx21XqVKFZfXX3YnT550TmS6M3mV06Tinj17nGMcDofthKhlnTk6Maca11P/Y2SfeHnjjTdy3EbWz1MvuOAC2+WequuzZH0x/MQTT9gu98TkVWpqqvML98svvzzH99bExETna+Syyy4zlnvqPsRZNGwHsgkNDVXHjh29vp+VK1cqMTFRknTvvffmOvb666+XJJ0+fVqbNm3yWk6LFy+WJNWtW1f16tVzK6cNGzbYNjJ9+OGHdeedd0qSxo8fr/vvv18rV66UJA0bNkyNGjXyZOq2ypUrp9DQUEnSBx984FbD1SxffPGFMjIyFBERoVtuuSXXsVn3xd9//62//vrLGf/uu++cl7t3757j+rfddpvKlSvnVl533323QkJCbJfVr1/feblTp045biNr3NGjR3Xs2DGXZVnPgZYtW6pChQq55pJ1u9euXZvjmDZt2qhixYq2y6KiolS7dm1JyrUhbEGkpaXpr7/+0q+//qrt27dr+/btLg3mf/75Z4/uL7usx93hcKh37945juvYsaOio6Nd1rHjq/sQQNE6t7lwqVKldMMNNzgbP1esWFELFy5UWFiY7fqdOnVSUFCQ7bKkpCTndvKqOS699FKVL19ekuv7e0JCgn799VdJ0n333aeIiAjb9UuVKqX77rsv133k5vPPP5ckRUZGqk+fPgXeTl48UfNkf7/v2bNnjus/8MADeZ7gw1N+/fVX7d69W5L79aVk/1leuXJlvfvuu5Kk3bt36/7779fTTz8tSbriiis0ZswYT6Wdq5iYGEnSqlWrnLfNHZ543u/fv1+///67pDOf2zm9/sLDw93+/6FMmTJq166d7bIaNWooKipKknTllVfq0ksvtR2XveY79/Pf0/9jOBwO3X///Tlu4+qrr5YkHTlyxKgrC8OyLB04cEA7duxw1nLbt2/XRRddJMm7tdymTZuct6VXr145vreWLl3a+X7366+/KiEhwXacr+7D4ojJKyCb2rVrq2TJkl7fz8aNG52XY2JibM/EkvV3xRVXOMceOHDA6zn98ccfuebjcDj0xBNPSDrzYXfkyBHb7U2bNk2VKlVSZmam5s2bJ0m69tpr9dxzz3ntNmQXFhbmnMSZP3++atWqpYEDB+rLL7/M84Mh6744efKkgoODc70vbr/9dud62R+f7du3O/O4/PLLc9xXUFCQGjRo4NZtqlOnTo7LypQpk+9xx48fd1mWdbuXLl2a53Ng/PjxknJ/Tl5yySW53RxdcMEFtnkURHJyskaPHu08+1W1atV0+eWXq169eqpXr56uuuoq59h//vmn0PvLSdbjXqNGjVwnAENDQ505Za1jpyjvQwD+p0aNGnr22We1bdu2XD8rrrzyyhyXbdmyxXlGrC5duuT5/p71Hpn9/T37GVIbN26ca87Zz46YX1u2bJF05p+5nCbIPMETNU/WfVKjRg3nxIedChUq5HlmRU/JXl82b94819tVqlQp59icPss7dOigBx98UJK0ZMkSnThxQmFhYfrwww9znMjxtB49ekiS/v33X11xxRXq3LmzZsyYoV27duW6niee99k/n7MmGHLi7heztWvXznUyM6tOK2wtJ3nmf4zy5cvn+iVrVh1il0tBfPHFF7r99tsVHR2tmJgY5wRz1t8XX3whqWhqOUlq2rRprmOzL8+pnivq+7A4Y/IKyKZs2bJFsh93T297rpMnT3o4k7M8nVOFChU0evRo5/WQkBB98MEHOX574Q2TJk3SHXfcIenMabNfeeUV55FOjRs31iuvvOL8dio7T9wXWacfvuCCC/K8zXkd5ZQlt0K+RIkS+R6XkZHhsqwgtzslJSXHZXn945GVy7l55Ne+fftUr149Pf/88/rll1/y3F5uORdW1j82OR0tlV2lSpVc1rFTVPchAN/q27evtm3bpm3btmn79u3atWuXjh07pj179mjcuHF5vqfkVr944jMt+/tUXrlceOGFBdqfdPYf0qyjbbzFk/eJO+/3hblP8sMb9eXEiRNdJrpeeOGFXCdLPe3GG2/UpEmTFB4ertTUVM2bN0+9e/dW7dq1VaVKFT366KO2R+F4spaT8q7VPFHLSWc/14uylpNyfg64m69dLvlhWZYeeugh3X777friiy/ynMQpilpOyvv1nVXLnbtedkV1H54Pgn2dAOBPimpiJfsb0+bNm3P8Kdi5qlSp4q2UnDnVr19fs2fPdnu9rMN3z5Wenq63337bef306dNasWKFevXqVag886N06dJavHix1q9fr48//lgrVqzQ1q1blZGRoY0bN2rjxo0aP368Fi5cqObNmzvXy7ovypcvr+XLl7u9vxo1anj8NhSlrNt9yy23aNy4cT7Oxn3du3fX3r175XA49MADD6hz58669NJLVaFCBYWGhsrhcCgzM9P5+s7+E0JvKaqfiAAoHipWrOhyFER+5Va/ZK853nnnHbVo0cKtbeY0IVYc3t88WfP40/2R/bFesmSJ20d85fYP+owZM3TixAnn9e+++06DBw8u0tv9+OOPq2PHjpozZ46+/fZbrVmzRomJidq/f7/eeecdTZ06Vc8//7xefvll5zqeft4HCn/8H8Md06dP13vvvSdJatCggfr166emTZvqoosuUkREhPM9rkePHvrggw+KpJaT/Ov1DSavgHzLPjuedTiyneTk5ByXZT90tEKFCj7/wJDO5nTixIlCFdBZXnrpJa1fv17SmUmkpKQkPfXUU2rZsmWRT/I0adLE+TOG48ePa8WKFZo5c6Y+/fRTHTp0SPfcc492796t8PBwSWfvi+PHj+vSSy8t0KRmVvFz5MgRZWRk5LqNw4cP53v73lCuXDn9/fffOnXqlEeeA0Xh999/1w8//CBJRuGaXW5HN3lS1qHfBw8ezHNs1iH62Q8XBwBPy15zREREFOj9Pfs/9Hm9v7nz/peT8uXLKz4+PsfeMZ7iiZon6z5x5/YW5j7Jj+yPdZkyZQr9Wf7rr79q0KBBks7WcsuXL9eECRM0YMCAQm07vypWrKh+/fqpX79+yszM1NatW/XZZ59p0qRJOnbsmEaOHKnGjRurffv2kjz/vM+rVvOnWi6Lv/yP4Y6s/mq1atXSjz/+6KzJz1UU9Vz2uuzgwYO5/oQz+88tqee8j58NAvmU1UhRcj2c+Fw7duzIcVn2/jtr1qzxTGI5cPcbg6yc9uzZU+jeWmvXrtWoUaMkSW3bttWyZcsUEhKi48ePq3v37rkeEuvtbziioqJ0xx13aMGCBXrqqacknWlEmzUBIp29L9LS0lx6B+RHVp+rtLQ0/e9//8txXEZGhrZu3VqgfXha1u3euHGjTp065dNc3H0eZL9vc2tUn9fj6KnnXVZxvHfv3lwL2dOnTzt7uwTKRCGAwNSgQQPne1xBa47sTc03bNiQ69i8luemYcOGks68ZxekVUJR1jxZ98nevXv177//5jju8OHD2rdvX4H2kSW/t0sqfH156tQpde3aVampqYqIiNDatWud/X2GDBmiX375pdD5FlSJEiXUsGFDjRgxQt9//70z/vHHHzsve+J5n71naV4nTSpovehpRfk/hjvyW8/deeedOU5cWZalzZs3eyy3nGSvy3766adcx2Z9UX/uevAOJq+AfMp+1FBuH1QfffRRjstuuukm5++f33jjDa8e+prVgD4tLS3XcVlnB7QsS6+//nqB93fixAl169ZNGRkZKleunGbMmKGrr75aI0aMkHTmgzS3M9S4m68n3Hjjjc7L2Rs/3nHHHc4P29dee63Q2/7ggw9yHPfFF1/kWvQWpaznQGJiombMmOHTXLKfOCG350L2Mz/ldrTjlClTPLK/vNx0002SzryOcrsP58+f7+y3lrUOAHhDhQoV1KxZM0nSnDlzCnSESOXKlZ1nPvvkk09y7DeTnJzsMoGQX1l9Kk+ePKmpU6fme/2irHmyv9+///77OY6bOXNmoes8dz+jGjZs6DzSZurUqUpNTS3wPocMGeL8cm3ixIm67LLLNHv2bJUqVUppaWnq2rVrjrl46jPVHQ0bNnQeIZW9lvPE875KlSrOo24++eSTHG9LamqqPvnkk3xv3xuK8n8Md7j7msyq53Kr5RYtWpTnUZme+D/i6quvdjbFnzVrVo6/tDl+/Ljz/e6yyy7zeq8+MHkF5NsVV1zhPCx00qRJtm+OH3/8ca4fYmXKlHGevebHH39U//79c/0J4sGDBzVt2rQC5Zv1Rnro0KFcmx+2bdvW+dO6V155Jc/ic9u2bVqyZIkRf+qpp5yn7Z06daoqV64sSXr22WfVsmVLSWdOCZ7TN1hZ+ebndMh29uzZo5UrV+Y65ptvvnFezj4pWbduXecpj+fOnatXX3011+3s3bvXmKxs3ry5s6Hpm2++afvNzeHDh9W/f//cb0gR6tmzp2JjYyVJAwYM0KpVq3Id/8MPP+R5HxdU9gIgt+dC7dq1nZdnzpxpO+btt9/WokWLPLK/vNx1113O5/zIkSNdztCVJS4uzvlzi4iICD3wwAMF3h8AuGPIkCGSpKSkJN177725nnU3LS1Nb731ljHx0bdvX0lnfibzzDPP2K7bv3//AjeMlqRu3bo5+0r997//zfUzJj4+3ogVZc1z1113Ofc3YsQI/fHHH8Z6v/76q0aOHJnrtt3h7mdUiRIl9Pzzz0s6Uwf16NEj13/ik5KSNGnSJCO+YsUKTZgwQdKZib6HH35Y0pmfdGV9qbd9+/YczyDtqc9USZo3b16uzbk3btzo/CXEuW0pPPG8f+SRRySdeb7ldHufffZZ/f3333nelqJQlP9juMPduj6rnluyZIntTwN3796txx9/3GP7y01YWJgeeughSWee51lfwGdnWZaeeOIJ54Rp1n0OL7OA84QkS5LVsmVLY1nLli1zXGZn8ODBzu21aNHCWrhwobV582brq6++snr37m2VKFHCatGihXPMjBkzjG2kpqZaTZs2dY6pX7++NWnSJOuHH36wtmzZYi1btsx68803rfbt21uhoaHW1VdfXaDb/e233zr3cf/991tr1661du7c6fzLbteuXdYFF1zgHH/HHXdYs2fPtn766Sdr48aN1pdffmmNHDnSatasmSXJeuaZZ1zW//TTT53rPvDAA0Yuf/75pxUdHW1JsurWrWudPHnSGPPf//7XuY3Ro0dbW7dudeYaHx/v9u1evny5Jcm67LLLrP/+97/WZ599Zq1fv95av369tWDBAuu+++5z7qdBgwZWZmamy/r//vuvVbNmTeeY66+/3po2bZq1du1aa/Pmzda3335rjR8/3rrpppusEiVKWPfcc4+Rw+rVq60SJUpYkqyIiAhryJAh1urVq63169dbkydPtmJjY62QkBCrQYMGliSrevXqxjb27t2b6/Po3NsryVq+fHmO42bMmOEct3fvXmP52rVrrbCwMEuSFRQUZHXt2tX65JNPrI0bN1rr16+3Fi1aZL3wwgtWvXr1LEnWm2++aWwja/vDhg3LMQ/Lyvt1V6VKFUuSVaNGDWvRokXW77//7nwuJCUlWZZlWZmZmdYVV1zh3Od9991nLVmyxNq4caO1cOFC695777UkWddcc02ueSUlJVklS5a0JFkNGza0vvnmG+uPP/5w7i/7c3XYsGHObdn5/PPPLYfDYUmyoqKirJdeeslas2aNtW7dOuvVV1+1Klas6Fx/8uTJttvw1H0IwH9lf9/O67We1/q5ve9nefrpp53jK1WqZL344ovWd999Z23ZssX64YcfrJkzZ1oPPvigVbZsWUuSdfz4cZf1T58+bV111VXObdx8883WwoULrU2bNlkLFy602rZta0myGjVqlGtePXv2tCRZ1apVs81z2bJlVnBwsCXJCg4Oth544AFr0aJF1qZNm6wff/zRmj59unXvvfdaoaGhxrpFWfNYlmXNnz/fuX6ZMmWs0aNHW2vXrrV+/PFHa9SoUVZ0dLQVHR1t1apVq9Dv1e58JlrWmc/FDh06OPO6+OKLrXHjxlkrVqywtmzZYq1cudJ65513rC5duliRkZFWuXLlXPZz9OhRq2rVqpYk68ILL7QOHTpk5JK1fYfDYX333XfG8p07dzr337ZtW2vlypXWjh07nPmePn3a7dtdrVo1q0yZMlbPnj2t9957z1q9erWzDhs2bJjzMQwKCrI2bNhgrF/Y531aWppLnXH77bc7n4+LFi2ybrvtNkuS1aRJE+eYFStWGHm4+3ldrVo1S5LVs2fPXMfl9t7hif8x8nqdZsmrrnS3rn/llVec4+rUqWO999571k8//WStXLnSGjZsmBUdHW2VLFnSatiwYa55de3a1ZJkhYWFWVOmTLG2bdvm3N/Bgwed4/Kqr5OSklz+D7jnnnuszz//3Nq0aZM1f/5864YbbnAua968uZWenu61+xBnMXmF84YnJ6+Sk5OdxYzd3w033GBt3749z0mHpKQk6+67785xO9n/WrVqVaDbnZGRkWuu5/rjjz9cPqRz+xs+fLhzvb///tsqV66cJcmqWbOm8eGfZfbs2c71+/btayyPj493KSaz/+Wn6Mte1Of2d8kll1h79uyx3UZCQoJ13XXXubUdu8k6y7KsmTNnWiEhIbbrBAcHW++++67VvXt3Zy7nKurJK8s6M4EVGxvr1u2eNWuWsX5uBVV2eb3uJk+enON+s98XW7ZscRaddn/16tWz/v777zzzGjhwYI7byH6f5jV5ZVlnHvesSUC7v6CgIGvUqFE5ru+p+xCA/yrqyavMzExr+PDhzomh3P4iIyNtv2Dav3+/Vbdu3RzXa9u2rbV06dJc83LnH7qvv/461/f1nN6Di6rmye6VV15xfmFx7l9ERIT1+eefe+S92t3PRMuyrFOnTll9+/bNMa/sfzVq1HBZt0uXLs5lX3zxhW0uhw8ftmJiYixJ1kUXXWQdOXLEGJP9S8Jz//LzD3rWZE5uf2FhYTnWSJ543v/555/WxRdfnOvz/quvvnJeX7dunbGNopy8sqzC/4/hqYkXd+v6U6dOOSfA7f7Cw8Otjz/+OM+8tmzZkmP9lf0+dae+3rt3r3XJJZfket9dc8011r///mu7PpNXnsfPBoECiIiI0LJlyzRy5EjVq1dP4eHhKl26tBo3bqxJkybpu+++U2RkZJ7biYqK0oIFC7R69Wo99NBDqlu3rqKiohQcHKwLLrhAjRs31uOPP64vv/xS3377bYFyLVGihL755hsNGTJE9evXV6lSpXJtnlinTh1t3bpVc+bM0T333KOqVasqPDxcoaGhiomJ0Q033KAhQ4Zo06ZNeuGFFyRJlmXpgQce0L///qugoCBnTwQ7Xbt2VZcuXSSd+TnXl19+6bL8oosu0vr16/Xggw+qVq1aLn0T8uO6667TihUrNHjwYLVq1Uq1atVSVFSUQkJCdOGFF6pt27aaMmWKtm7dmuPZDytVqqRVq1bp888/V9euXVWzZk1FREQoJCREFSpUUIsWLfTMM89o5cqVmj59uu02evbsqY0bN6pr166qXLmyQkNDddFFF+m+++7TDz/8oIceekhJSUmSpOjo6ALdVk9r1qyZdu7cqSlTpui2225z5l2yZEnFxsaqbdu2GjlypH7//Xf16NHDa3n07dtXCxYsUNu2bVWxYkUFB9ufILdBgwbaunWrHn30UVWrVk0hISG64IIL1KRJE40fP17r1693qw/BmDFj9O677+q6667TBRdcUKCzTGbp2bOnfv/9dz399NO69NJLFRkZqfDwcF188cXq06ePtmzZosGDBxd4+wCQXw6HQy+88IJ27NihgQMHqlGjRs73uqioKF122WXq2rWrZs2apYSEBNumyZUrV9aWLVv08ssv64orrlB4eLjKlCmjZs2aafLkyfrqq68UGhpa6FzbtWunPXv2aNSoUWrRooXKlSunoKAglS5dWg0bNlS/fv1cGiVnKYqa51wDBgzQDz/8oLvvvlsVK1ZUWFiYqlWrpt69e2vjxo267bbbCn1/SO5/JkpSSEiIJk+erJ9//llPPvmk6tWrp+joaAUFBSk6OloNGjTQgw8+qPnz5+u3335zrjdnzhxnG4S+ffvq1ltvtd1++fLlNWPGDDkcDu3fv1+PPvqoMWb27NkaN26cmjRpoujoaJezdefH8uXL9frrr+uee+5RvXr1VKFCBQUHB6t06dK66qqrNGDAAP3666/q1auX7fqeeN5XrVpVP//8s4YPH57j8z77zw39oZ4riv8x3OFuXR8SEqIvvvhCb7zxhho1aqSIiAiFh4erVq1aevTRR7V582ZnS4/cNGjQQGvXrlWXLl1UtWpVhYWFFTj36tWr6+eff9akSZPUsmVLlStXzvl/xM0336wPPvhAq1at4iyDRchhWT7u4gYA57latWpp9+7d6tatW67N3QEAAOB/Xn75ZQ0dOlTBwcE6fvx4gb98BZAzjrwCAB/asGGDs6lk1llxAAAAEBgsy9K8efMknTnyh4krwDuYvAIAL9q1a1eOy/7991/16dNH0pkzm3Tq1Kmo0gIAAIAb9u3bp/T09ByXv/DCC9q+fbukM20DAHhHzj+WBgAUWps2bVSjRg116NBBV155paKjo3X06FGtWbNGkydPVkJCgqQzp3MuX768j7MFAABAdjNnztSMGTN0//3365prrlHlypV1+vRp/fbbb5o1a5ZWrFghSbrsssucX0oC8DwmrwDAiyzL0vLly7V8+fIcxzz22GN6/vnnizArAAAAuOuvv/7SmDFjclx+ySWX6IsvvihUg3AAuaNhOwB40cqVK7VkyRKtWrVKCQkJOnz4sIKDg1WpUiVde+21evjhh9WiRQtfpwkAAAAbcXFxmj9/vr755hvt2rVLhw8f1smTJ3XBBReofv366tChg3r37u2RM20CyBmTVwAAAAAAAPBbNGwHAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJq/+3YcMG3XrrrSpTpowiIyPVrFkzffzxx75OCwAAwG9RPwEAgKIQ7OsE/MHy5cvVrl07lSxZUp07d1ZUVJQWLFigTp06KS4uTs8884zH9pWamqpt27ZJkipUqKDgYB4CAAD8UXp6ug4fPixJqlevnkqWLOnjjPwL9RMAADiXt+onh2VZlke2FKDS09N1ySWXKD4+XuvWrVODBg0kSYmJiWrSpIn27dunHTt2qFq1ah7Z34YNG9SkSROPbAsAABSN9evXq3Hjxr5Ow29QPwEAgLx4sn467382uGzZMu3evVv333+/s/CSpOjoaD3//PM6deqUZs2a5bsEAQAA/Az1EwAAKErn/THXK1askCS1bdvWWNauXTtJ0sqVK93eXnx8fK7L09PTnZenLrhKdWqecl5PHGl+o3j8WJQRu+T1J9zOxx0ZXz5oxIJufc+tdbc/NsV5OTE4ROPqXCpJWvREC11YOtwzCcJnvm8z1Yjd+O3DPsgEAIpeQkKC82ifChUq+Dgb/0L95Ln6KcsVkx91Xv73RJp6z9wkiZoqEFE/ATifeat+Ou8nr3bu3ClJql27trGsUqVKKlWqlHOMO2JjY90eW6fmKdW/9KTz+r/hIcaYYyfM34defZmZa2GkbzptxILd3MfpoLPF1L/BoQouXV6SVPmiKoqJptAKdOVDyhixKlWqFH0iAOBj9FhyRf3kufopS/b8EhJTFFz6T0nUVIGI+gkAzvBk/XTe/2wwMTFR0pnD3O2ULl3aOQYAAADUTwAAoGjxNaKHxcXF5bo8+yF0iSObuHxbWO7db43xe641DzGeHjPdiPVO6J3fVJ2Wv9HeiLXp7t66R/4p67x8rCRPp+Lm0D/2/5QAAOBJ53P9hOKH+gkAPO+8n23I+sYwp28Hk5KSVLas+wUGhwQDAIDijvoJAAAUpfP+Z4NZvRrs+jIcOHBAJ06csO3nAAAAcL6ifgIAAEXpvJ+8atmypSTpm2++MZYtXbrUZQwAAAConwAAQNE67yevbrzxRtWsWVNz5szR1q1bnfHExESNGjVKoaGh6tGjh+8SBAAA8DPUTwAAoCid9z2vgoODNW3aNLVr107XX3+9OnfurKioKC1YsEB//vmnxo8fr+rVq3tl38ePRbmcytmuuWjjH6YasRLXP+TRPA4fLlPgdRtcv8V5+ZAjXFKtwicEv/HA3w/6OoV8m13VfM10+8t8bRXGqLCPXK4/n9alwNsqinyLwlcNxhuxW7YOcGvdxVe8ZsTu3N6vkBkFvk/rvmnELih3zIjd8ONQt7Y3pfwsI/boPz3znRcgUT9JnqufUPxQP9mjfjJRP3ke9VPxdd5PXklSq1at9MMPP2jYsGGaN2+eTp8+rXr16mns2LHq1KmTr9MDAADwO9RPAACgqDB59f+aNGmir776ytdpAAAABAzqJwAAUBTO+55XAAAAAAAA8F9MXgEAAAAAAMBvOSzLsnydxPkkPj5esbGxkqSN/9uhqy+r7Vw2PWa6Mb5a1QNG7OpV04xYmbA9bu3/pZC5RizIYT4Fvss8acQeq5FqxH7ZU855ObmUQ5/2LSVJWju4tWKiw93KKS92Ob9wunOBtzc0yNxemZIZRuyZ5K5G7JPabxmxjjsfN2J3l/jAiH2a2d3dFA1vljG39+Qx97Znd3tHZBT8/vOV/o55Rmyi5ZueKitajHC5vu3X6sYYdx8fO/7UhLS4PH/stAmeYcS+TX/Ao/sYVMJ83o7NdO95OyHyQyNm975k99nRO6G3W/uw40/PP1/L/pkdFxenKlWq+Dij81dxrp+yZH9vTUhMUfPRyyQVvKaifqJ+kqifqJ88j/rJnj89/3zNW/UTR14BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fs0bC9iuTUcLYxjaTXN4MgrjdDOny41Yo2XjvZIDp5oLgp4w/dNRxmxG3963geZuGffgw8aservveeDTIDzGw3b/Udxrp/sUFPBH1A/ASgIGrYDAAAAAADgvMPkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8F+zoBeIhNc1H99xcj1DhsofdzAfxMeESqr1PIF5qLet7vnZ40YpfMe9Pr+910yyAjdvVXY72+3+JsW4f+RqzeZxN9kAmKBeonIEfUT6B+Kj6KQ/3EkVcAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/xeQVAAAAAAAA/BYN2wPQSyFzjdgtrS81YnbNRY+l1TRiZcL2uLXf1dcPN2LXrRrm1rrTY6Ybsd4Jvd1a11eKoqnd11e9YsRu3vKsR/fhaYH4WLZY/pKvU8jRzIumGbFe+x/yQSbFW1E0F7VDc1HPC7TmovAfgVg/SdK8hvNU+mSm87q/f+ZSP9mjfvIs6qeiQf1UfBSH+okjrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LRq2+1DGlw8qfdNp5/Xlb7Q3xhw+XMaIBTmijVjjpaPd2qddc1G7JqS/3tzNiF23ymza+Ev7Z5yX/wkOk2pfY7tff2pIadfgsXSpFCN29x/uNbVb0WKEEVu6ro4RG53ZyYi521x0d89HjNjFs95xa93CGBX2kRF7Ps18LL9qMN6I3bJ1gFv7WHfjECPW7PuXjdjkC943Yo8d6eHWPgpjSNA8I/ZyhutjufiK14wxd27v59b27ZqL2j2nbvhxqBH7tvEYI9Zmw3NG7NO6ZrPNu/940q38PK0wzxX4F7vn6Tc2732jbN77Roaa7y21qx41YvfteqyA2dHMtzgrbvVTlisXTbDdd6fNnRQTHe5Oml5F/eQ+6ifqJ0+jfio+qJ8KjiOvAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtGrb7UNCt7yn4strO6226u7deq+D3jNh/C5GHXXPRy76ebTPSbDj62uJGzsupUQ6ptjGkyEwqazakfOKo2ZBy1d+RRqysoozY3W7ud+NWs2FrsMNyc233/L6lrhG72M11ezvMxn7TrS5GLKqk2bT2eNpgt/axbnsVI3aLzbhnHGbzzloXmE+aZjbrLj9mzrW724rwrqAPjNjCDPdecN+WOGbE1gZPd7neJDPGGHOne6nZsntO3WAzbv3P1YxYG5txJUpkurXfhx1zjdhUq7Nb67rL7rmyqoT5vLBr0OtPBruZc1fHHCP2oXW/V3IqanZNcJ8NMRshj7JZ97vMk0bsv4VoLmrH7r2+l0f3AF8pbvVTlulGpGhQP9mjfqJ+on7yPOon6qfC4MgrAAAAAAAA+C0mrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH7LYVmWZzsjIlfx8fGKjY2VJG383w5dfVn+O5x/UvstI9Zx5+Nurbv6+uFG7LpVw9xa91ia2QSxTNge5+WExBQ1H71MkrR2cGvFRIe7tV1/sPHm54xYo6/HuLXuzq59jVjKiQgjduWiCflPLBe/3PUfcx8LX/XoPoqzj2tNNmL3ebjhIVCc2b331f7wbR9k4j3ZP7Pj4uJUpYrZMBdFozjXT3YCpaaifjr/UD8BhUP9VHAceQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbwX7OoHz2fbHpuh00NkGnEf+KWuMaXD9FiP2y57bjVhHN/dp11z0l/bPGLHXFjcyYtMts7lo9iakSWllJI1wMxP/4m5z0XHhc4zYVVdUM2JfbqxhxCbmPy2nBXUmGbF7dhSP5qLuNsGdGPWhEet/vGuB9+tuc9EBjnlGLDLI9TwXV9b8xxhzz44nCpaYpG8bm8/HNhvMprhf1jeb2J5ODzJiKSkljVjnPY8WMLvCWXT5a0as/f/6FXkegcrd50ZRsGsu+ozN62WC1cmIDQ2aa8RGZHT2TGL/b2qFmUbs4cO9PLoP+EZxq5+y5NXE3R9RP/kO9ZOJ+gk5oX5ynz/XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fv0vPKhxOAQ/Rsc6rx+rKT5cBxyhBux5FIOI5aQmFLgPP4JDjNiqVHu7eNMn6szDh8v7bx8KCm1wPn4Qky0eT8DAAAAAADfc1iWZeU9DJ4SHx+v2NhYSdJFfWcquHR5H2cESdo35jZfp+ARS68eZ8TabRrog0yKj6fsGo6eM7c7OtNsqDin+hQjdv8+3zT5BFAw2T+z4+LiVKVKFR9ndP7K/lhs/N8OXX1ZbR9n5HnZm7gfTCyjdq+eOQnO2sGt8/ySbW5N8zPHV42lAxH1k+dRPwHnL2/VT/xsEJBU/bkvCnX0GgAAAAAA8A5+NuhDi55oocoXFZ9vcQ8lpar9Wz9Kkmb3eUUVopKcy0qHrXFrG4tbzDZid/7YzTMJ2sieMwAAAAAA8D9MXvnQhaXDi22vpQpRSbow+pjzepkw925ndEqGESuu9xEAAAAAAMgbk1cAAAAIGP+eSCuWP/UvzElwEsODjJin7yO+TAQA+BIN24uYr5u/To+ZbsR6J/T2yLYTElPUfPQySWZz0exNSLP8dV8HI7br9+pGrEnrjUbsh6XNze0llDZiDz79mRHb9/PZXP4NCdXDlzWzzdnOuPA5Rmxgyv25roPcjY/40IgNONnVB5kAgCtff2bjLE5443sLfl5lxK7+aqxb61I/eR71EwB/RcN2AAAAAD5xT/3r9W9IqK/TAACcp/jZIAAAAAKGL054M6/hPCPWaXMnr+0vt5Pg7O97szF+3y7z/mhwzS9GbMPKq43Y/kOljFjnB792Xv5H4eqhO9xLHAAAL2HyCgAAAAHDFye8KX0y04gVVQ7nngQnLT3NGHMs1TzhTUXL7Hlld2KcxBNmB5ELdTKfWQIA4F38bBAAAAAAAAB+iyOvzjOeas6eX3bN2at+bDZT/zB8tBFr2+uwEQsNOW3Enn7tHSN2eEsNI7btl9rOy4kRJaTLzHxzQnNRzzufmot684QJAADv8eV79f6+N7scbVXU9VOqI1yKPnP5t99qKDrbUWjmjxDtUT95HvUT9RNwvuHIKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+i4bt8IrFLWa7nI45NKS6McauuejglMFGbFhJc1y7q/cZsTnDexixnxIijVioHM7LKVEOYznOD3cEvW/ElmSYzyE7d5f4wOX61cHuvZX+9xTNRQNRL8dHRqx2iDlu32nz/eRdq7M3UgJQDM2tOcV5OTE8SLqjsiRp364qOpZ6tqYq6vopNcohPXbm8vaDpRR+3HIu62XeDBRz1E9wF/UTPI0jrwAAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LRq2B6CXQuYasRdO+1dTuzt/7KaY6HDn9fi+PY0xbXsdNmJ2zUWHpppNSL+94hkjdu/jnxmx9imhRmzhe7c7LydFlNC3Mpu658f3TUcZsRt/er5Q2/QXI2yea0P97Ll2rpkXTTNivfY/ZMTcbS5q59PM7gVe1xc+qf2WEeu483EfZOJf+jrM5/fbNg1CZ1pdiiIdAF7m7/VT5z2POi8nJKZo9OhlkqQG1/yiilaKc1lR108HrQityDjzPnh5hZMqHZmZ281wG/WTf6F+MlE/2aN+gq9w5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv+WwLMvydRLnk/j4eMXGxkqS4uLiVKVKFR9n5DkJiSlq/v/NRdcObu3SsH1uzSnG+NCQ00asVNRJI5aYWMqItdk+wYhZL9c3Yp/PvNWIdY/r41bOACBJ71acYcT6HHrAB5mgqBXnz+xAc749Ftnrk8FL/lZ0SoZzWVHXT4nhJTT+7kqSqJUAuI/66fzlrc9sjrwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4LeCfZ0A/NOksu8bsSeO9ijw9v5KKG3Enn7tHSM2Z7i5j3sf/8yIpds0F3UM+dmI3WY5bLLpYxNDUZhaYaYRe/hwryLPA8gPu+ai02OmG7HeCb2N2IiQuUZs6OnOnkmsCE2I/NCIPZPc1QeZAP7N0/WTJO0/VEqJJ86eX6mo66eDVoTGZ3RxO194HvUTAhH1E/WTp3HkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/RcN22Cpsc9FzPfi02TT08JYaRuynhEgj1j4l1Ih9MesWI2bXnL3E0K1GLHsz1eORJaRuZY0x8A6ai/q3t8vNMmJ9/+3p9f3OqT7FiKWdCjFiD/z9oNdzcZddc1E7gdhc1E5EyXRfpwAEBE/XT5LU+cGvdaFOOq8Xdf1UIrGM9OqZyzMvX6Co5EznMm/cXpion/wb9ZP7qJ9QGBx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8Fv0vAIAAAD81D8Kd7me6gg3xqRGmX2rDloRRiwx3Pze2m5cicQyzsuHj5d2Xj4R4VD2774TElNscw4kMdHm/QkA8D9MXgWgoUFzjdiIjII3tZt50TQjtupvs/HndKtLgfex7+eaRmzbL7WNWKjM4mvhe7cbMftmf32MSPbm7Fm6HXjReflgYhm98+oISdLiFrMVnZLhXNZ5z6M2+3BPf8c8IzbR6lTg7S2oM8mI3bPjiQJvD7BTFM1F7YSFms0sMzM5MNjTXo+ebcSeTuzm1rq+em4MCTLfS1/OKPh7Kc5vgVg/SVIP3eEaiLYZ9JgZWpFhs9+7zdB4u3Gv2ufy4d1lXK6/M3qZ/cAAsm/Mbb5OAQGO+ql4o37yHzy7AQAAAD8SEx3OpEoRqf7cF8XiCDIAKO6K1ZFX+/fv1yeffKIvv/xSv//+uw4cOKALLrhA11xzjQYOHKimTZsa6yQlJenFF1/UggULdODAAcXExKhjx44aNmyYSpUq5YNbAQAAUHSon/zX1F/XGbHffqthxLYfNO/zyyucNGKdNrv3zfvMyxc4L5+IcDiPuJrd5xVViEpyLlvRqq+x7p0/undEgp3hsUuM2LC4O2xGuufL62casVtX9ZIkHUpKVfu3fizwtgEARatYTV69+eabGjt2rC6++GK1bdtWFSpU0M6dO7Vw4UItXLhQc+bMUadOZz+0k5OT1bJlS23dulVt27ZVly5dtGXLFo0fP14rV67UqlWrVLJkSR/eIgAAAO+ifvJf5U6fMmLRJzONWPhxy4iVjjTHudvfKSo5+7pnf6hRISpJF0YfO5tLtnYL+d2HHbvbUZjtlfFwfgAA3ylWk1dNmjTRihUr1LJlS5f46tWrdeONN6pv37666667FBYWJkkaN26ctm7dqkGDBmnMmDHO8c8995zGjh2riRMnavDgwUV6G4qLQ0mpLtf/DQk1xiRGmL9aTbFpOJpkM87dw7uPR9o0Js2hCWlSSdexhTmE3O52FGZ7x8KD3NoeBRkAIL+onwAAgL9zWJZlfsVRDLVr107ffPONNmzYoEaNGsmyLFWpUkVJSUk6cOCAIiPPNthMTk5WpUqVVLFiRe3evdujecTHxys2NlaSFBcXpypVquR7GxMiPzRizyR3LXBOn9Z904it2VHRiHVpt8WINfr6bNGakJii5sWgcWcgoz8GAF8aEWI2xB56uuANsX3NE5/ZgY76KWeeqp/8Xfb6bvCSv12Otrr5t3HG+DJhe9za7o+tXjBiVS/504hVeXuWu6kall5t5hccfKbJ9ZGwED3b4jJJ0trBrfkCEIDPUD+5p1gdeZWbkJAQSVJw8JmbvHPnTv39999q166dS+ElSZGRkbrmmmu0dOlSxcXFOe94d8THx+e6PCEhIZ+ZB46s5qLVn/vC16mct6o/9wUFGADAY6ifAACAPzgvJq/++usvfffdd4qJiVG9evUknSm+JKl27dq269SuXVtLly7Vzp0781V85WdscbV2cGtfp5CrxS3Onu40qWQJvdWmkiSzCWnpsDVubW/jfROM2EUXm0V4zOiJ+U3VaeUtbxuxoOCz33weCw3WyEZ1Crx9AADORf0EAAD8RbGfvDp9+rS6d++utLQ0jR07VkFBZ3oHJSYmSpKio6Nt1ytdurTLOLjP34/6sWsuKplNSMuEuXc7yp0ym6lWtDzbj6psWroRC84wYwAAeAL1EwAA8CfFevIqMzNTvXr10qpVq9SnTx91797d6/uMi4vLdXlCQoKaNGni9TwAAAAKgvoJAAD4m2I7eZWZmanevXtrzpw56tatm6ZMmeKyPOsbw5y+GUxKSnIZ566iaOZamOai2zr0N2J3/2H+nO1u27U72UYDTec9jzovJySmaPT/NyEtHbbG5WirY2k1jXXtmpC2WP6SEUt86U63ckn/oLkRC+6+1oi12zQw1+0kJKZINMsH4GOB3FwUZ1A/2aN+OuPOH7udcyT5o8aYQKmfqJ0A+AvqJ/cUy8mrzMxMPfDAA3r//ffVpUsXzZw5UyVKlHAZk9WrIat3w7ny6ukAAABQnFA/AQAAf1Ui7yGBJXvh1alTJ33wwQfOPg3Z1a5dW5UrV9aaNWuUnJzssiw5OVlr1qxRjRo1aCAKAACKPeonAADgz4rV5FXWoe7vv/++OnbsqNmzZ9sWXpLkcDj00EMP6cSJExoxYoTLshEjRujEiRPq06dPUaQNAADgM9RPAADA3xWrnw2+9NJLmjVrlkqVKqU6dero5ZdfNsbcddddatCggSRp4MCBWrRokcaOHastW7aoYcOG2rx5s7755hs1btxY/fr1K9obAAAAUMSonwAAgL8rVpNX+/btkySdOHFCI0eOtB1TvXp1Z/EVGRmplStX6sUXX9SCBQu0fPlyxcTE6JlnntGwYcMUHh5uuw1f+6T2W0as487H3Vq33mdmc9HCGBc+x4gNTLm/wOP8iV1zUbsmpJnDrzJi/xndxYjNfMHch11zUU8LxPvezrDguUZseLpvmhuuu3GIy/Vm35v/6Hna69GzjdjTid28vl8AxR/1U96on9xH/eRfqJ+on4DiolhNXs2cOVMzZ87M1zrR0dGaOHGiJk70bFECAAAQCKifAACAvytWPa8AAAAAAABQvDB5BQAAAAAAAL/F5BUAAAAAAAD8VrHqeXW+cLe5qLtWtBhhxDZuNRtrtu/wgxG76opqbu2jMA0uv286yojd+NPzBd5eTjbeN0HlTp1yXm+x/CVjjF1z0RLDthixJzbXttmD2YTUXT+1+a8RCw5Od17+NyRUuqyZ7br+3lx0V7dHjVit2VOM2NWXHCiKdAzTKs0wYg8dcG0wavf4NP3WvumxO3699ykj9nTiG0bsl/bPGLErF00wYj+2Mrvd2j2/7XzbeIwRa7PhObfWtbPplkFG7OqvxhZ4e/Av71Y0Xy99Dj1gxGZXnWrEuv31sEdz8fRzF4GP+snz9ZO7ny/+WD/lVjtJ1E+FRf1E/QT3UT+5hyOvAAAAAAAA4LeYvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgth2VZlq+TOJ/Ex8crNjZWkhQXF6cqVarkext3l/jAiH2a2b3AOQ0uMc+IBTvMp0XH2zcYsRmLmxixiVanAudSFPo7zt7elCiHvn4sUpL0adISVbRSnMuiYo4a6z49zGwa+kS7n41YrUUfG7EyYXuM2N4H+hixGjPeNWKjS35kxK5tssN5+UhoiJ5uVF+StHZwa8VEhxvj4Tn3lJjtcn1BZjcfZYJA1N0xx4h9YPl3Y+CBDvNzYpzNe33bYLPh6DfpZsPRQOGJz2x4BvWT7yQkpqj56GWSpJsnJyv8+Nnb+MyjXxrjA6V+onYqetRPKAzqp8DhrfqJI68AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+i8krAAAAAAAA+C0athcxmr/6l+xNSL3drPNYWk0jZteEtCCK8nb4kxUtRhixG34c6oNMUBi7ez5ixC6e9Y4PMgFc8ZntP3gsfMfXNYa36idf3y5fon4qHqif4K9o2A4AAAAAAIDzDpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAvxXs6wRQtL6+6hUjdvOWZ32Qif9L/6C5EQvuvtatdfc+0MeI1ZhhNhf1ZhP34uaPLo8bsRt+fMsHmcDTaC4KwN9RP7mP+sm/UD8VX9RPON9w5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvMXkFAAAAAAAAv0XD9vMMzUXd525zUTs1Zrzr1ji75qI0IbVX9yOaiwIAfIP6yX3UT/6F+glAccGRVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/F5BUAAAAAAAD8Fg3bA9CbZT4wYk8e617g7e3u+YgR+31LXSN22y//MWIL6kwyYvfseKLAuRSF7DkfCw+SbqkqSVp5y9sqm5buXNZu00C3tvdTm/8asWWrrzBig1O7uLW9860J6c93DjBif+6pYsQSEyON2PHkMCP22JEenkns/40Ln2PEBqbc73L9uyajjTE3rR9sxD6uNdmI3bfrMSNm95xq+u1II/ZDyxeN2LUrzdjSq8cZsd17KxkxT993dla0GGHEbvhxqNf3a2dI0Dwj9nJGJx9kYs/ucXP3fclXxpY0Xy+DUu83Yp7+HLMTiJ9P8C7qp8L78vqZKpOS4bxeKuqkMYb6qWhQP1E/UT/Zo34qHH/+fOLIKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN9i8goAAAAAAAB+y2FZluXrJM4n8fHxio2NlSTFxcWpShWzsaK/+uUus+HolQtf9UEmnpOQmKLmo5dJkl758VddkHbauezGn553axubbhlkxE4mRxix61YNK2CW9rI3IT2YWEbtXj3TyHHt4NaKiQ736L6K2lcNxhuxW7aajUmLwmulZxuxfkndPLb9JfUmGrE7tvX32PYBFFwgf2YXN4H8WAR6/ZS9Vjq3xvi+6ShjfKDUT8WtdpKon6ifAP/grc9sjrwCAAAAAACA32LyCgAAAAAAAH6LySsAAAAAAAD4rWBfJwD4i2Ohri+HhMQUt9b7NyTUiKWEhhgxd7fnrqS0Ms7Lh4+Xdl4+lJTq0f0UteLQcwIAgOLo3BrjSFjB6x1f10/FqXaSqJ8AFH80bC9igdxw1F1Lrx5nxNptGuiDTPKWvQkp/EOncSc0NrOTW2Mfd8w1Ym9ZnT2dUp6mVphpxB4+3KvI8/CGUWEfGbHn07r4IBOg6J0Pn9mB4nx4LPy1fqJWCgzUT/6F+gnnMxq2A14QEx2ufWNu83UayGbewFIe/5YVAAAUDLVSYKB+AlDc8bNBQGdOkRzIDiWlqv1bP0qSZvd5RRWikpzLtnU0v0m7ZvGTRmxxC/OUxnf+aJ7SeM2db7q1vaGxS4zYiLg7jNio/x+XEunQdz3NU2QDAADfC/Ra6Vy51U4S9RMA+BsmrwAVrz4BFaKSdGH0Mef1/WmnjTF2tzc6JcOtcRe4ub3w4+Yvku3GRZzgl8sAAPi74lQrnevc2kmifgIAf8PPBgEAAAAAAOC3OPIqAA0NMpssjsjwbJPF3g6zyeB0y70mg/7QXNRbxoXPMWIDU+73QSY529axs8u3hQ1XvmeMWd822YjVqpNpbqtDfyO2a3d9I2b3Q4L2jffkkekZFUqmS5JOlHTkOm5i1IdG7C2rq1v78LRhwa6vweHpvXySR1Gway5anBusAii+qJ98x9/rp3NrJ4n6yRuon2YaMeonwH0ceQUAAAAAAAC/xeQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAb9GwPQB5urmoHXebi55v/Km5aE6uWfykyymV7ZqL1lliNq3tHT7ciE18cLkRc7ex5A+baxixm2zGDTh5pmloQmKKZo5eluP2+h/3TXNRO8PTvf8a9GfFpbmou42Vx5Y0Gw0PSnXvveD16NlG7OnEbm6tC2lwiXlGbHRmJx9kguKA+sl3/L1+Ord2kqifvIH6qZevU/AI6if/V1zrJ468AgAAAAAAgN9i8goAAAAAAAB+i8krAAAAAAAA+C0mrwAAAAAAAOC3aNgOW1ElRxux46mDfZAJ8mtxi9mKTslwXq9VJ9MYY9dcdHrKMCPWrtQgI/ZW3HNGrNHXY4xYkCPPVCVJP985QJL0T3CYVKeFJKl/7EKFHbdcxh0sccpYt5mjpBHbkZlhxA6WSDNiRx1mbPPpvm7l3DTkHZfrP51+xK314F8Wh8a5Nc7d5qJ2iqK5aHFtyikVn9uB8wf1U2A6t3aSqJ/OrEv9BBP1k/8rLrfjXBx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0bDdh75vM1XlQ8o4rx/6J9oY88DfD3o9j1FhHxmx42n+01x0RMhcIzb0dGcfZBIY7vyxm2Kiw53Xt3Xob4yZ+OByI2bXXHTpibFGrEzYHrfyiEt3a5jqLx4vSUpITJFGLzuTX9xdLrchP+yeL3NO9y7QtnLiyQaj/vT89qdcxoXPMWIDUwre+NNOo/SKHt2erxRFU053nxsdS8w2Yp9ker/p6sMOM7+pVsGfu70cZz4Xk/VvgbcB76F+co8/vaf7u3NrJ4n6SaJ+cpc/5UL95D7qp8CrnzjyCgAAAAAAAH6LySsAAAAAAAD4LSavAAAAAAAA4Lf8YvIqMzPT1ykAAAAEFOonAABwvnBYlmV5a+OPP/64Xn31VYWFheU4Zt++feratavWrFnjrTT8Snx8vGJjYyVJcXFxqlKlSpHuf3rMdCPWO8GzzRhR9BISU9T8/5t1jl/7P12Qdtq5bNfui4zxDx/uZcQ23vycEWv09RgjdiytphGza0LqboPC1dcPlyQdCQ3R043qS5LWDm5d4IajQHExt+YUI9Z5z6M+yMR9zzjmGbEJlvcbonqLrz6zqZ9M1E/wtNxqJ4n6CQhU1E++563PbK8eefX222+rcePG+t///me7fO7cubrqqqv0008/eTMNAACAgEH9BAAA4Mqrk1ejRo3SH3/8ocaNG+utt95yxpOTk9WrVy917dpV4eHh+vrrr72ZBgAAQMCgfgIAAHDl1cmr5557TqtXr1blypX11FNP6c4779TSpUt11VVX6f3339dtt92mX375RTfddJM30wAAAAgY1E8AAACuvN6wvUmTJtq6dau6du2qzz//XLfeeqv279+vSZMmafHixSpfvry3UwAAAAgo1E8AAABnBRfFTo4fP674+HhJkmVZCgoKUkRERFHsGueway76VYPxRmzddrOp2vB0s1kk/M81i590adbZ2s317JqL2rFrLmrXhHToaXOcnetWDZN0pnGq/r9xKgD/by5qJ5Cbi/oj6if/Qf1UvJ1bO0nUT0Cgon4qvrx+5NXixYt15ZVXasWKFXr00Ue1dOlSlS1bVg8++KC6dOmipKQkb6cAAAAQUKifAAAAzvLq5NVjjz2mDh06SJIWLlyoyZMnq02bNvrll190zz33aN68eapfv/55c5pnAACAvFA/AQAAuPLq5NWUKVPUqlUr/fzzz7rzzjud8ejoaH388cd69913dfjwYbVq1cqbaQAAAAQM6icAAABXXp28Gj16tL799ltVrlzZdvmDDz6ozZs368orr/RmGgAAAAGD+gkAAMCVVxu2Dxo0KM8xderU0dq1a72ZBvJwy9YBZswHecAzhsYuUfhxy3m9fWOz8ecPm2sYsSCHua24dDMWa/OuYddc1K4JqV2z0uJgSvlZRuzRf3oWeHvzLn7biP35d7QRG5hyf4H3URgjQuYasaGnvd+QeGLUh0as//GuBd7ebUHm4/ZFRsEfN8BTqJ8CA/VT8XFu7SRRPxUF6ifqJyA/iuRsgwcOHNCnn36q33//XSdPntS0adMkSYcPH9bevXtVr149hYSEFEUqAAAAAYH6CQAA4AyvT15NnjxZzzzzjNLS0iRJDofDWXwdOnRIzZs315QpU9SnTx9vpwIAABAQqJ8AAADO8mrPqyVLluiJJ55QvXr1tHjxYvXt29dl+eWXX64rr7xSCxcu9GYaAAAAAYP6CQAAwJVXj7x65ZVXVLVqVS1fvlyRkZHatGmTMaZevXpavXq1N9MAAAAIGNRPAAAArrw6ebV161Z1795dkZGROY656KKLdPDgQW+mgQJ4xjHPiE2wOvkgE/dNrTDTiD18uFeR5+FrI+LuUEx0eK5jbiqCPOyai9o1If0kdqgkKSmihNS5vNfz8obCNBe102l337wH+ZBdc9Hvm44yYjf+9LxH91uY5qJ2aC4Kf0X9FLionwKTO7WTRP3kadRP1E9Afnj1Z4OZmZl5NhI9dOiQwsLCvJkGAABAwKB+AgAAcOXVyau6devmekh7enq6Vq1apXr16nkzDQAAgIBB/QQAAODKq5NXXbt21ZYtWzR8+HBjWUZGhgYMGKA9e/aoR48e3kwDAAAgYFA/AQAAuPJqz6snn3xSS5Ys0UsvvaQPP/xQJUuWlCTdd9992rhxo/bt26e2bdvqwQcf9GYaAAAAAYP6CQAAwJVXJ69CQkK0dOlSDR8+XFOmTNHRo0clSfPnz1fp0qU1aNAgDR8+XA6Hw5tpIA/rbhxixGpdUNutdVdfb34rfN2qYUZsfMSHRmzASc82D/RVc9Fd3R41YrVmT/HoPn6+c4ARq794vO3YUbFLFHHCcl6vUDLdGGN337u7D3cfcztZzUWz6xg3QpJ0MLGM3nx1RI7rftNorBFru3GQW/stjDnVzcfy/n2uj3l+Hh93uPuc+r3Tk0bsknlvGrHNtw40Yg2/HFfA7Oy521x0+939jNgVn77m0VzgOx9We8eIdf3zESO2oM4kI3bPjic8mkth3qt8jfopMFA/FY4/1U/n1k4S9VNhUT+5h/oJEvWTu7w6eSVJoaGhGjlypF5++WX98ccfOnLkiEqXLq1LL71UQUFB3t49AABAwKF+AgAAOMurPa+yczgcuuSSS9SiRQtdccUVRVp4jR07Vg6HQw6HQ+vWrTOWJyUl6T//+Y+qVaumsLAwVa9eXc8++6xOnDhRZDkCAACci/oJAACgCCevfGX79u0aNmyYIiMjbZcnJyerZcuWmjhxoi655BL1799fdevW1fjx49W6dWulpqYWccYAAAC+Rf0EAAD8iUd/NlizZs0CredwOLR7925PpiJJOn36tHr27KkGDRqodu3amj17tjFm3Lhx2rp1qwYNGqQxY8Y4488995zGjh2riRMnavDgwR7PDfCWlEjXHignSpo9URISU4zYP8Fhbo07Ehri1jg7SRHmfPnBxDKSpMPHSztjh5LMf3qOhplvV+7utzASw82jHIpivwDOH9RPgG+dWztJ1E+FRf0EwNMclmVZeQ9zT/Xq1Y3moadOnVJCQoIkKTg4WOXKldO///6r9PQzTRBjYmIUGhqqvXv3eioNpxdffFFjxozR5s2bNW7cOM2aNUtr165Vs2bNJEmWZalKlSpKSkrSgQMHXL5dTE5OVqVKlVSxYkWPFobx8fGKjY2VJMXFxalKlSoe2zaKr8VXvGbEQoLPNhI9Ghas51u51yQWnrdvzG0FXndbh/5GrN5nEwuTTrH1ca3JRuy+XY8VeHtPOeYZsTesTgXeXnE2u+pUI9btr4d9kIm9ceFzjNjAlPvdWteuqfDev6MlSYnWv3ol/UxjX29+ZlM/5Y36CQWRW/1E7eR71E9Fg/rJd6ifPPuZ7dGfDe7bt0979+51/m3ZskUxMTG6/vrrtXr1aqWmpiohIUGpqalatWqVrr/+elWuXFlbt271ZBqSpM2bN2vkyJEaNmyYLrvsMtsxO3fu1N9//61rrrnGOCw+MjJS11xzjfbs2aO4uDi39xsfH5/rX1YhCnhS2bR0vf31b75O47xV/bkv+DYRQIFRP1E/oehRO/ke9ROA/PDq2QYHDRqk1NRU/fTTTy4NRkuUKKFrr71W3333nerXr69BgwZpyhTPnRo3LS1NPXr0UIMGDTRwoHmK0yw7d+6UJNWubf+tS+3atbV06VLt3LnT+W1fXtwdB3jD2sGtC7xu/9iFRmxi3F0FTyafDiWlqv1bP0qSZvd5RRWiklyWZ0683FgnKMw8jfX+/1UzYrFX7TJiSfHljVjMaPMbu/iB5mmcU4+HS5KOBIXp6YtaGMsBoDCon4CiM2r5TrX6xjwlvbuon6ifABQNr05eLVq0SL169crxzDjBwcG6/fbb9f7773u0+HrhhRe0c+dObdq0Kdez8iQmJkqSoqOjbZeXLl3aZRzg72Kiwwu8bthx8xfEhdleYVSIStKF0cdcYpmOk8a4IMdpI5aWnmbEKpVINmIlLbMJsd3tPZVpfiOYklHsz3UBwIeon4CiUzYtnfpJ1E8A/J9XJ6+SkpLyLFwSExM9WtysXbtW48eP14svvqgrrrjCY9t1V16HyCckJKhJkyZFlA0AAAg01E8m6icAAM5vXp28uvzyyzV37lwNGDBAF198sbF8586dmjt3rseKpPT0dPXs2VNXXnmlnnvuuTzHZ31jmFPxl5SU5DLOHUXRQLS/TZO8iYVokjf5gveN2PJj5jcjn2R2M/cb9aER63+8a4Fz8XfDgucasasvOWDE7tzez63t/dHlcSNW96O3jFhiovktV/e4Pm7tw93H6GCJU25tz9O+aTRW0v+fDee6SySdOcT93G8KSwzbYqxrjbzSiK1Y3tCIVa4bb8RO2tynu3uaPxsICTO/Ub2wzv9vz4qQ/v/I+wWN5yg6JdM5xt3Hxy7fvTYNZu2eUwvqTDJi9+x4wohNj5luxHon9HYrP0+za+54/75H3Vq3MM1F7RxymD+bCETuPg8Kw93mog87zPfIqVZnI+bpzzG75qLuvvfl9vyLj4/XK7FPFjivgqJ+8g7qJ9+hfvI86ifqJ+qnwqF+Crz6yauTV0OGDFGHDh101VVX6cEHH9S1116rihUr6tChQ1q9erWmT5+u5ORkDRkyxCP7O3HihLMPQ2hoqO2Y5s2bS5I+++wzZyPSrHXOlVdPBwAAAE+jfgIAAHDl1cmr9u3ba+bMmXryySf1+uuv64033nAusyxLpUuX1owZM3TnnXd6ZH9hYWF68MEHbZetWrVKO3fu1J133qkKFSqoevXqql27tipXrqw1a9YoOTnZONXzmjVrVKNGDZqIAgCAIkP9BAAA4Mqrk1eS1KNHD3Xo0EELFy7Uzz//rMTEREVHR6t+/fpq3769s6mnJ4SHh2vatGm2y3r16qWdO3dq8ODBatasmTP+0EMP6aWXXtKIESM0ZswYZ3zEiBE6ceKEnn/+eY/lBwAA4A7qJwAAgLO8PnklSVFRUerevbu6d+9eFLvLl4EDB2rRokUaO3astmzZooYNG2rz5s365ptv1LhxY/Xr18/XKQIAgPMQ9RMAAMAZDsuyzG56xVCvXr00a9YsrV271uWbQ+lMw9EXX3xRCxYs0IEDBxQTE6OOHTtq2LBhioqK8mge8fHxzsPo4+LiiqRBKfzDihYjjNgNPw51a127prCPHelhxB63afb3lk2zPzsv2jRTfTHdvXU9ISExRc1HL5MkfVNyti50uJ6e2bI7vfJ/fzFC1sv1jVhIhHn650N/mK+9dSvM5p/X37LWiKWfOjPvf6hEuO4rd4skqe+HRxWVfLbhqN3jY9ewdngR3sfZudsYsjhbdPlrRmx/wgVGbPfRMCM2wc3mmM+XMBtrjsp0b93Xo2cbsacTzcbPdkaGfmTE/nuqi1vr4iw+s6mf4HvUT7mjfipa1E/UT8ibtz6zvX7k1alTp7Rw4UJt2LBBx44dU0ZGhjHG4XDovffe82oeM2fO1MyZM22XRUdHa+LEiZo4caJXcwAAAHAH9RMAAMBZXp28+vPPP9WmTRvt3r1buR3gVRTFFwAAQCCgfgIAAHDl1cmr/v37a9euXerevbt69+6tKlWqKDi4SNpsAQAABCTqJwAAAFderYSWLVumG2+8UbNmzfLmbgAAAIoN6icAAABXXp28yszM1FVXXeXNXRR7s6tONWLd/nrYB5n4zsyLzNN399r/kA8yKRx3m4vasWteacfd5qJ2dmSa/VRGhJhNKYee9n5Tyv3/q6a0dNcmoSuWm81Au1kOI+YY8rMR29KmpxH77se6Rsyu+efgEmWN2I2N9kiSjoSFSNecifXYfo9iosONsXlt31eqhZwX5+rIVWqq2UjU3deau9xtLmrH3eaidmguGtionwqP+on6SaJ+kqifPI36ifoJvmNz+gnPadq0qX777Tdv7gIAAKBYoX4CAABw5dXJqzFjxmjZsmWaP3++N3cDAABQbFA/AQAAuPLqzwa/+OILtWrVSp06dVLLli3VsGFDlS5d2hjncDg0dGjBDwkGAAAoLqifAAAAXHl18urFF190Xl6xYoVWrFhhO47iCwAA4AzqJwAAAFdenbxavny5Nzd/XnC3uej3TUcZsfCIVCPWYvlLbm3vrqAPjNjCjO5uretpgdhcNBAdLJFmxOac7u2DTKTYq3apUolkl1jluvHGuJAIM2e75qL1vjXP2HXl2CuM2Kd1DxuxR3qZDUxDwk9Jkg45wiVdaiyXpOkx041Y7wTf3J92Dp82fzU+IfJDI/ZMcteiSMcnjhyL8Ml+B5WYZ8TGFqIxaXHW12E2PX67EI2VAwX1U+FRP1E/FRXqJ+on6qeiQf3kvuJaP3l18qply5be3DwAAECxQ/0EAADgyqsN2wEAAAAAAIDC8OiRV3/99Zck6aKLLlJQUJDzujuqVq3qyVQAAAACAvUTAABA7jw6eVW9enU5HA799ttvqlOnjvN6XhwOh9LT0z2ZCgAAQECgfgIAAMidRyevevToIYfDoejoaJfr8L4bf3reo9uzay76ca3JRuy+XY95dL93BL1vxJZk9PDoPmDvqMNs3ukrSfHlVdKKdImdTIw0xgWHljVi3/1Y14jZNRe1Bm03Yne/sNiI/d7pSSMWdeExSVKYdTY27ZJPFZV8NtAvyX+ai46PMBuJHrP51fhrxbi5qJ35iRlGrG8R7DfRsvIeFAA+iH3XiHWP6+PRfRSH5qLuoH7yHeonFBb1E/UT9RP1U35QPxWcRyevZs6cmet1AAAAuKJ+AgAAyB0N2wEAAAAAAOC3mLwCAAAAAACA32LyCgAAAAAAAH7LYVnFpPNZgIiPj1dsbKwkKS4uTlWqVPFxRoB/SEhMUfPRyyRJawe3Vkx0uMvy3T0fMdb5aeVVRuz+fY8asU/rvmnE7v7DbCR6LK2mESsTtqfAOQOB6Nd7nzJil81/wweZ+B6f2f6DxwKwR/0E+Afqp7O89ZnNkVcAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/FVxUOzpx4oR27Nih5ORkXXfddUW1WwAAgIBF/QQAAFAEk1f79u3T008/rS+//FKZmZlyOBxKT0+XJK1Zs0Z9+vTR5MmTdcMNN3g7FeRgSNA8I/ZtiWNG7KfTZsPHAQ5z3VM2+3jD6lSQ1ALCtEozjNhDBx7w6D7Ghc8xYqEhmUasX1I3j+63KMypPkWSlBgeJLWvLEmKHzhApzJTXMaFhJnnlrj+lrVGbHCJskbskV4/G7HfO5kNRy+ZZzYXtWtCeuiBmyVJh4NKShfdKEl6u9ZClTpxNseBKfcb69n54spXjVjCIfM27DscYcQqR6cZsceO9DBiI0M/MmL/SzefP3Myu+aYp6e8Vnq2EQvE521h9HKYj8dMq4sPMrFn11x0cAnzvX50pvm+fmvQTCP2ZUYvI9axhPk8+CTTs88Du8+n8QH0WUT95P+onwqH+qlwqJ+onwLxeVsY1E/UT1792eBff/2lZs2a6csvv1T79u3VvHlzZT+5YdOmTfXPP//oo4/MJyIAAMD5iPoJAADAlVcnr4YNG6ajR49q5cqVmj9/vtq0aeOyPDg4WNddd53WrFnjzTQAAAACBvUTAACAK69OXi1dulQdOnRQixYtchxTrVo17d+/35tpAAAABAzqJwAAAFdenbw6cuSIqlevnusYy7KUlmb+7hgAAOB8RP0EAADgyqsN2y+88ELt3Lkz1zHbtm1T1apVvZlGQBsVZvazaHH1LiN2w49DC7yPlzPMBmxrg6e7tW5kkNkEMiTTUeBc7i7xgRH7NLN7gbfnaetuHGLEHjrwshG7x6aZ3oJCNNNzt3mlnWHBc43Y8PTORqxpyDtGzK7JrKfdv+9RSVJCYorGjl4mSUo9Hq6UDNe59QvrxBvrJv59gRG7sZHZNDQk3GyDG3XhMbfyy2ouml3FGV9LkqzEMtKrZxqO9t11l2Kiw93aZna3/fKffK+TX/89ZTaz7OMwnxdFwZ+ai95s0xzza5vmmP1sGle+VojGlZFy7z1yYtSHRqz/ce83hbVj11zUjl1zUTuebi5qx1+aixYE9VPhUT9RP0nUTxL1U2FQP9mjfnIf9ZNnefXIqzZt2ujzzz/XL7/8Yrt89erVWrZsmW699VZvpgEAABAwqJ8AAABceXXyasiQIQoPD9f111+vkSNHateuM994ffXVVxo6dKhuvvlmlS9fXs8++6w30wAAAAgY1E8AAACuvPqzwerVq2vp0qXq3Lmzhg4dKofDIcuydPvtt8uyLFWtWlXz589XTEyMN9MAEGCOBIWZQSvCCCWVMA8zPxIWYsQOOcxxYeYvNnQqMcWIHQ4qaaaSWObMsuOlz+4jKdXcoB9LjSr4z1MAeBf1E4CCoH7yPuonwHcclmXZvAV5Vnp6upYsWaKffvpJR44cUenSpdW0aVO1b99eoaGh3t69X4mPj1dsbKwkKS4uTlWqVMn3Nt4sY/Y1ePJYwfsaLL7iNSO29lezILb7ze6COpOM2D07nihwLiNDzR4Vdr839yc/tfmvEWv67UiP7uO7JqON2E3rBxuxqRVmGrGHD/fyaC7umlJ+lhF79J+eRuznOwdIkv4JDtODdXI+sxa8b9+Y24yYp1/jK1qMMGKF6TlTGEOCzF4Mdj1sCmNO9SlGLKtPSXE0tuQcIzYo1ew54+nPMTueeO564jO7MKifzqJ+yh31kz3qJxQF6ifqp8KifnKPV4+8cu4kOFgdOnRQhw4dimJ3AAJQ+fQ0Lfp1udpf1srXqZy3qj/3hdYObl2gxqkAPI/6CUBeqJ98j/oJKBpenbzKyMhQcnKySpUqpRIlzPZaWcsjIyMVFBTkzVQABIj3dvyoy2aYZyVa0Nj8RiI5xTw8vsf2e9zaz7RLPjViD/1+txF7u9ZCI9Z3112Szhzq3v6tHyVJs/u8ogpRSc4xpcPWGOvt6mt+Q1brbfObtC1dxhmxqz4aaMTW3/uqEWsy3zz7zspb3jZiLb/q67yc/XYA8D3qJwD5Rf1E/QQUd16dvBo+fLjGjRunuLg4VahQwVh+5MgRVa1aVYMHD9YLL7zgzVQABIjy6Wm231xFp2QasRLJZszdb72iks1fTNutW+qEe+MqRCXpwuhjzutlwswxiRlpbm3rr9PmqantxpU7ddqtcWXT0t0aB8A/UD8ByC/qJ+onoLjz6tkGP//8c9144422hZckVahQQTfddJMWLVrkzTQAAAACBvUTAACAK682bC9TpowefPBBTZgwIccxAwYM0PTp03XkyBFvpeFXfN38tSgUpsFeIDYchf+bHjPdiPVO6F3o7SYkpqj56GWSZPQ6OJZW0xj/zeUDjNh9ux4rdB4FMfmC952Xj0eW0Ntdy0oybwdwPvPVZzb1k4n6KXfUT/AG6icT9ROQN299Znv1yKvTp0/b9mrIzuFwKDU1sE6RCgAA4C3UTwAAAK68OnlVq1YtLVu2LNcxy5YtU40aNbyZBgAAQMCgfgIAAHDl1cmru+++W1u3btULL7ygjIwMl2UZGRkaOnSotm7dqo4dO3ozDQAAgIBB/QQAAODKq2cbfOaZZzR37lyNHDlSc+fOVatWrXTRRRdp//79Wr58uXbv3q1LL71UAwaYv2MGAAA4H1E/AQAAuPLq5FWpUqW0atUq9e3bV5999pl27drlXFaiRAnde++9mjx5skqVKuXNNFDE3G0uatcE8r+nCt8Esjj6uNZkI+arRpX+ZFjwXCM2PL2zEfNEc9G87Oo71OVUzr9sMv+pbPu/8Ubs3Ypmc88+hx7wbHI2DiaFOi8nZzq8vr+itOq64Ubs+tXDjNi2Dv2NWL3PJnolp4L4sNo7Rqzrn4/4IBP/8m7FGUasKF4zRYn66fxE/eR51E/2qJ8KjvqJ+ilQFYf6yauTV9KZ0znPnz9fBw8e1MaNG5WYmKgyZcqoUaNGqlixord3DwAAEHConwAAAM7y+uRVlgsvvFC33XZbUe0OAAAg4FE/AQAAeLlhOwAAAAAAAFAYXj/y6tdff9WkSZO0YcMGHTt2zDhrjiQ5HA7t3r3b26kAAAAEBOonAACAs7w6ebVy5UrdfPPNSktLU3BwsC688EIFB5u7tCzLm2kEtNlVpxqxbn89XODtzbxomhHrtf+hAm+vMIqiCWRxYddcdEk9szHiHdvMBoqFMSLEbOg59LTZ0NPT7BpBrlje0IgNT+/u9Vy+uPJVI3bbL/8xYrXeHqGY6LPNQy+x2ZZdc9GOcSNsRnq/eWL2xqwJiSmaP3qZJOnjRh8p+mSmc5mv3h/m1pxixDrvca+Z8c/bahqx623GHT8WZcQ+u+QNI9bh96fc2u+ksu8bsaAS5ufb5ZftM/OzaYgaiM1FB5WYZ8TGZnYq8Pbsmwqbr4/RJT8yYoNTu7i1D09/znoC9VPhUT9Bon6SqJ88jfqJ+skbqJ/c49XJq+eee07p6emaNm2aevbsqaCgIG/uDgAAIOBRPwEAALjy6uTVzz//rM6dO6t3b74hAgAAcAf1EwAAgCuvNmyPjIzkdM4AAAD5QP0EAADgyquTV7feeqtWr17tzV0AAAAUK9RPAAAArhyWF7t9Hjp0SNdee61uvvlmjRkzRhEREd7aVcCIj49XbGysJCkuLk5VqlTJ9zbsmqNd2+YnI1b9vffc2t6KFmbDw41bzYZ9A052NWLfNh5jxNpseM6t/RYXv95rNiO8bL7ZtLAwfmrzXyPW9NuRHt2Hp827+G0j1ml3XyO2q5vZRLLWbLPZ5OIrXjNid27vV6Dc8mNapRlG7KEDZxoeJiSmqPn/N+qc/MtGlTt9yjmmMI/PsTTz9VcmbI8R+6X9M0bsykUTjNiPrV4wYi2Wv+S8nP12rB3c2qVxqqdtumWQEbv6q7Fe2x/yrzDvae9WNF8vfQ6ZDUKLosmnJz6fPPGZXRDUTybqp+KH+ske9RP1kx3qJ/9H/XSWt+onr/a86ty5s0qVKqW33npLM2fOVJ06dVS6dGljnMPh0Pfff+/NVAAAAAIC9RMAAIArr05erVixwnn5xIkT2rx5s+04h8PhzTQAAAACBvUTAACAK69OXmVmZnpz8wAAAMUO9RMAAIArrzZsBwAAAAAAAArDqw3bsztx4oR27Nih5ORkXXfddUWxS7/kq+av8IzXo2cbsacTu/kgE/83LnyOERuYcr8PMimcIUHzjNjLGZ0kFW2jTrsmpBuuNRs0pp82D6i9ZeuAXLddlLcDRcOuoeeJk2FG7NF/ehZFOgHLHz6zqZ/O8IfHAgVH/eQ+6ifPon5CflA/eYa3PrO9fuTVvn371L59e5UtW1aNGzdWq1atnMvWrFmjyy67zKW3AwAAwPmO+gkAAOAsr05e/fXXX2rWrJm+/PJLtW/fXs2bN1f2A72aNm2qf/75Rx999JE30wAAAAgY1E8AAACuvDp5NWzYMB09elQrV67U/Pnz1aZNG5flwcHBuu6667RmzRpvpgEAABAwqJ8AAABceXXyaunSperQoYNatGiR45hq1app//793kwDAAAgYFA/AQAAuDI703nQkSNHVL169VzHWJaltLQ0b6aBPHzbeIwRW/9zNSP231NdjNiX9ScYsVt/fsYzifkhu+aiv7Q3b++Vi8z7pTB+aPmiEbt2pRnzJ+42F/2905NG7JJ5bxqxBXUmGbF7djyR/8TyqXK0e+9P6+99VeVOnXZeL8zjY/ecOvi32Vy08Q9mU8nfbzXv95XXvmTEWv7wQgGzK5x1Nw4xYs2+f9kHmRRv5cslGrHICLPhqKdNKvu+EXviaA8jNj1muhHrndDbo7kE8ucT9VNgoH5yH/WT+6ifXizwPqmfUFjUT/79+eTVI68uvPBC7dy5M9cx27ZtU9WqVb2ZBgAAQMCgfgIAAHDl1cmrNm3a6PPPP9cvv/xiu3z16tVatmyZbr31Vm+mAQAAEDConwAAAFx5dfJqyJAhCg8P1/XXX6+RI0dq165dkqSvvvpKQ4cO1c0336zy5cvr2Wef9WYaAAAAAYP6CQAAwJVXe15Vr15dS5cuVefOnTV06FA5HA5ZlqXbb79dlmWpatWqmj9/vmJiYryZBgAAQMCgfgIAAHDlsCzL8vZO0tPTtWTJEv300086cuSISpcuraZNm6p9+/YKDQ319u79Snx8vGJjYyVJcXFxqlKlio8zKpxFl79mxNr/r1+R5wH4QkJiipqPXiZJWju4tWKiw722r68ajDdiZcsdM2KXfDnHiG26/iEjduNPzzsvF+XtgO/Mu/htI9Zpd18fZCK9XW6WEev7b08fZJI7X39mUz+d5evHwtOon3A+o35CIKF+yj9vfWZ79cgr506Cg9WhQwd16NChKHYHAAAQ8KifAAAAzvBqz6vWrVvr/ffN0z5mN3v2bLVu3dqbaQAAAAQM6icAAABXXp28WrFihfbt25frmD///FMrV670ZhoAAAABg/oJAADAlVcnr9yRnJyskJAQX6cBAAAQMKifAADA+cTjPa/++usvl+vHjh0zYpKUkZGhuLg4LViwQNWrV/d0GsiHT+u+acRKlMg0Ynf99rQRS0kp6ZWcsvuk9ltGrOPOx72+X3f92OoFI9Zi+Use3cfSq8cZsXabBnp0H76y+VbzdjT80ry902OmG7HeCb0LvN/xER8asQEnuxqxkaEfGbH/nupixFbe8rbKpqU7rxfm8bF7Tt2y1XxOrbzWjNk1F7161TSbvTxvE/O+75uOMmLZm5/Ce4qiueiIkLlGbOjpzkbsisv3eT2XuTWnGLHOex71+n4Livop8FA/FQ71U+FQP5mon+AN1E/+Uz95fPKqevXqcjgckiSHw6HXX39dr7/+eo7jLcvSK6+84uk0AAAAAgb1EwAAQM48PnnVo0cPORwOWZal999/X/Xr11eDBg2McUFBQbrgggvUunVr3XzzzZ5OAwAAIGBQPwEAAOTM45NXM2fOdF5euXKlHnjgAT311FOe3g0AAECxQf0EAACQM49PXmW3d+9eb24eAACg2KF+AgAAcOWwLMvydRLnk/j4eMXGxkqS4uLiVKVKFR9nhEAw+YL3jdhjR3r4IBP/8rDDbG5YLcR8Szt82jyx6jGZTXVnWmYj0ftLmI1JI60gSVJqlEOrHyslSVo7uLViosOdY+wes4NJoUZseLrZjLEoHEur6bx8MLGM2r06QpJ5O4qzW4NmGrEvM3p5fb9POeYZsTesTkbs9ejZRuzpxG5eyQn2+Mz2HzwWKAjqJ3vUTwVH/UT9hLx56zPbfEfysO+++0633nqrKlSooJCQEAUFBRl/wcFePQAMAAAgoFA/AQAAnOXVqmfBggXq1KmTMjMzVa1aNV1yySUUWgAAALmgfgIAAHDl1UropZdeUnh4uBYtWqTWrVt7c1cAAADFAvUTAACAK69OXv3xxx/q3r07hReAYu9QUqrL9eOR5q+ykzMdRiwhMcVrOeUmKa2M8/Lh46Wdl8+9HYHofOk5geKL+gnA+YL6yb9RU8GfeLVh+0UXXaR7771Xr7/+urd2EXACpeGoXSPHqZZvGiMWxtvlZhmxvv/29EEmgWlEiPk8GHo68J4HEyLNpqHPJHct9HYTElPUfPSyQm8HnrVvzG1ujetr8z73dgC+z/mTQSXMZqpjM81mqi/ZvLe8UIj3ltElPzJig1PNBsLu+rbxGEnS4VOJ6vrLmctF+ZlN/WSifipa1E+FQ/2UO+qnwGFXU1E/eR71k3u82rD93nvv1Xfffaf09HRv7gYAfCImOtztiRIUnerPfeGzb2QBT6B+AlCcUT8FDmoq+BOv/mxw1KhR2rhxozp16qSJEyeqatWq3twdAPjE2sEF/2nPx43Mbzzu21jwbzwK4lBSqtq/9aMkaXafV1QhKsm5rHTYGmN8wuD+Rixm9EQj9u1N04xYm+8eMmJft5xuxC6uu8+I1Z76khHLLvvtAAIZ9ROA8wH1k3/UT3aoqeCPvDp5Va9ePZ0+fVrr1q3TwoULVaZMGUVHRxvjHA6Hdu/e7dF9f/bZZ5o8ebI2b96s5ORkxcTEqFmzZho3bpzzsHNJSkpK0osvvqgFCxbowIEDiomJUceOHTVs2DCVKlXKozkBKJ4K0w8g+mSmR7dXWBWiknRh9DHn9TJhZi4ZlvkNnF3OZVPNo0bsxpVJzTBi5TPS3FoXKI6onwCcD6ifqJ+A/PDq5FVmZqaCg4NdvjG0a7HlybZblmXp0Ucf1dSpU3XxxRerc+fOioqK0t9//62VK1fqzz//dBZfycnJatmypbZu3aq2bduqS5cu2rJli8aPH6+VK1dq1apVKlmypMdyAwAAyAv1EwAAgCuvNmz3hddff139+vXTY489pjfeeENBQUEuy9PT0xUcfGbObtiwYXrppZc0aNAgjRkzxjnmueee09ixYzVq1CgNHjzYo/l5ouHo0CCzUduIDJrk+UpWY7rs2mx4zgeZSKPCzEOon08r2kOoz0cL6kwyYvfseMIHmRRM9sapawe3dvmG7lhaTWN8mbA9RZZbfuR2O3xlUtn3jdgTR3v4IBMURKA0CfcE6icUNeonUD/5L1/XVNRPgc1b9ZNXG7YXtZSUFA0fPlw1a9bU66+/bhRekpyFl2VZmjZtmkqVKqWhQ4e6jBk6dKhKlSqladPM3xsDAAAUJ9RPAADA33n1Z4PZ/frrr/r999+VnJys7t27e2Uf33zzjY4ePaoHHnhAGRkZWrx4sXbs2KEyZcropptuUq1atZxjd+7cqb///lvt2rVTZGSky3YiIyN1zTXXaOnSpYqLi3Pp8ZCX+Pj4XJcnJCTk70YBAIDzFvXTGdRPAACc37w+ebVhwwb16dNH27Ztc8ayiq9Vq1bp5ptv1ty5c3XnnXcWel+bNm2SJAUFBenKK6/Ujh07nMtKlCih/v37a/z48ZLOFF+SVLt2bdtt1a5dW0uXLtXOnTvzVXzlZywAAIAd6icAAICzvPqzwf/9739q3bq19u7dq/79++uWW25xWX7dddepfPny+uSTTzyyv0OHDkmSXn31VUVHR2v9+vU6fvy4Vq1apTp16mjChAl6++23JUmJiYmSZHv2HkkqXbq0yzgAAICiQP0EAADgyqtHXg0bNkzSmW/0atWqpeHDh+urr75yLnc4HGrevLk2bNjgkf1lZp45ZWpoaKgWLlyoypUrSzpT5H3yySeqX7++JkyYoL59+3pkf3bi4uJyXZ6QkKAmTZoUah80F/UvvmouaseuuejUCjON2MOHe3k9lxEhZmPcoaeL53M3kJqL5iVhcH+XUzlXedtsLupuE9LdPR4xYhe//04hMwwsNBe19/VVrxixf/41J0O6/fWwW9srzPvNzIvM/ky99j/k1rreQv1kon4qfqif7FE/BSbqJ8+ifrJ3vtdPXp28Wrlype655x6XXgnnqlq1qr7++muP7C/rW8BGjRo5C68sV1xxhWrWrKldu3bp2LFjzrE5fTOYlJTksk13FeczEQEAAO+jfgIAAHDl1Z8NHj9+XBUrVsx1TEpKijIyMjyyv7p160qSypQpY7s8K56SkuLs1ZDVu+FcefV0AAAA8AbqJwAAAFdePfIqNjbWpdGonc2bN+viiy/2yP5atWolSfrtt9+MZadPn9auXbsUGRmpChUqqFKlSqpcubLWrFmj5ORklzPmJCcna82aNapRowYNRAEAQJGifgIAAHDl1SOvbr/9dn3zzTf67rvvbJd//PHHWrdune666y6P7O/iiy9W27ZttWvXLk2b5vobzDFjxujYsWPq0KGDgoOD5XA49NBDD+nEiRMaMWKEy9gRI0boxIkT6tOnj0fyAgAAcBf1EwAAgCuHZVmWtzZ++PBhNWzYUAcPHlTPnj114MABffnll3rzzTe1du1affTRR6pataq2bNmS794IOdm9e7datGihQ4cO6bbbbtMll1yiLVu2aNmyZapWrZrWrVunSpUqSTrzDeE111yjn3/+WW3btlXDhg21efNmffPNN2rcuLFWrlyp8PBwj+SVJT4+3vltZFxcXJ49Hr5qMN6I3bJ1gEdzAorK901HGbEbf3reB5kgu4TEFDUfvUyStHZwa8VE5/99z90mpHZWtBhhxG74cWi+c/DE7fB3m24ZZMSu/mqsDzLxvKVXjzNiu/dWMmKPHTGbuE6rNMOIPXTggULnlN/PbE+hfjJRP+F8Rv3kn4pL/WSnuNVU1E/Fo37y6pFXFSpU0MqVK9W4cWO99957+uKLL2RZlp544gl9+OGHaty4sZYtW+axwks68+3hxo0b1atXL23atElvvPGGdu7cqccff1zr1693Fl6SFBkZqZUrV6pfv3767bffNGHCBP3+++965pln9P3333u88AIAAMgL9RMAAIArr/a8kqSaNWtqzZo12rp1q9atW6cjR46odOnSatq0qRo3buyVfcbGxmrGDHMW0U50dLQmTpyoiRMneiUXAACA/KJ+AgAAOMvrk1dZGjRooAYNGhTV7gAAAAIe9RMAAEARTl5lSU9Pd55B54orrlBISEhRpwAAABBQqJ8AAMD5zOOTV3v37tXy5ct17bXXqk6dOi7LPv/8cz344IP6559/JElly5bV5MmTdd9993k6jWKD5qIoTmgu6v++vWmayqamO6/fsa2/MWZ3j0eM2MXvm81F7ZqQbm9rNouUgtzKza4hZbtNA91at7goLs1F7RTmsbRrLmr/PH3Hre29XW6WJOlo5pEC55Rf1E+eRf2E4oT6yf9RP/k36id7gVY/ebxh+7vvvqs+ffooLCzMJb5r1y7dd999Onz4sKpWrapLL71UR48eVdeuXbVlyxZPpwEAABAwqJ8AAABy5vHJqx9++EENGjRQtWrVXOKvv/66UlNT9fjjj2vv3r3avn27FixYoIyMDE2aNMnTaQAAAAQM6icAAICceXzyau/evWrSpIkR//rrrxUaGqpRo0Y5Y3fddZeuu+46rV692tNpAAAABAzqJwAAgJx5fPLq8OHDKl++vEvsyJEj2r17t5o2baqoqCiXZVdddZX279/v6TQAAAACBvUTAABAzjzesD0kJET//vuvS2zTpk2SpEaNGhnjIyMjPZ0C8umrBuON2LrtVYzY8PTORmzR5a8Zsfb/6+eJtALGplsGGTFPNwVc0WKEEbvhx6Ee3YevbL+7nxG74tPXjNic6lOM2P37HvVCRq5eKz3biPVL6uZy3dOPj7vPqXU3DjFizb5/2Yh933SUEcup+Wub7x5STHR4rvm527TRrrnoFd+8b8S2tjKbRdo535qLBqKJUR8asf7HuxqxrIae2fX9t6dHc9m+6VIjdrFH9+BZ1E+Bh/qpcKifCof6yUT9ZI/6yf9RP7nH40de1alTR99//71L7JtvvpHD4VCLFi2M8X///bdiYmI8nQYAAEDAoH4CAADImccnr+655x7t3LlTjz76qH755RfNnz9fU6dOValSpXTzzTcb49esWaNatWp5Og0AAICAQf0EAACQM49PXvXr10/16tXT1KlTddVVV6lTp046fvy4hg8fbhzivnHjRu3atUtt2rTxdBoAAAABg/oJAAAgZx7veRUREaE1a9Zo4sSJWrduncqVK6eOHTvqjjvuMMZu3rxZ7du315133unpNAAAAAIG9RMAAEDOHJZlWb5O4nwSHx+v2NhYSVJcXJyqVDEbe2a3+IrXjNid2/t5ITNXg0vMM2KjMzt5fb+eZtekMiw03Yjds+MJr+eyu+cjRuziWe41bgS8KSExRc1HL5MkDft6n8qkZjiXdfj9Kbe2Ydd01V0Nls8wYo6xVxix6BcW57qd7Ldj7eDWeTZOhf9zp+GvN+X3MxveQ/1UtKifgLwVl/rJDjVVYCuu9ZPHfzYIAAAAAAAAeAqTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL/l8bMNwrOKormonUBsLmon7VSIEcvM9M2cbSA2Fx0XPseIDUy53weZFF9za5pNcTvvedQHmZxxcd19Kp+Rlu/1bvhxaIH3mfjSBiNmDdpuxD6t+6YRu/uPJwu8X3jesOC5Rmx4eucCby/lVJARs3vNJByOMmL9j3ct8H7Hljzz3pdo/VvgbcC3qJ8Kh/qpcKifvI/6ifqpOKF+cg9HXgEAAAAAAMBvMXkFAAAAAAAAv8XkFQAAAAAAAPwWk1cAAAAAAADwWzRsR7H2wN8P+jqFgFaY5qIToz40Yu42APy41mQjdt+uxwqciz/zZXNRO7WnvqSY6HCPbGvp1eOMWLtNA41Y9AuLjZhdc9HWv0w0YsuaJTkvHwkLkZpf7nZ+/R3zjNhEq3g0W/aVwjQXtTM4tYtb4+zeb2ZXnWrEuv31sBGze79p2vBMo9HDaYnSZrdSAIoV6qfCoX7yPuonz9VPznHr/utWftRPnkf95B6OvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt2jYDsAr3G0uaqe4Nhc939g1F3XX3X88acTsmos2XPme8/LBxDLSqyPc3kdxaS666ZZBRuzqr8b6IBPPm1ZphhF76MADRqww7zdly5rPqxt+HCpJio+Pl2InFHjbAJBf1E8o6vrpLPcatlM/+b/iWj9x5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0fMKAOB0KCnV1ynk6EhYiBE7mFjGefnw8dLOy/58OwojJjrc1ykAAAAARY7JKwAoIquuG27Eft5W04g9eax7UaRjq/1bP/ps33lqfrkZy6FBu1/fjkLYN+Y2I+Zuc9FRYR+Z614RZ8QK0yjW0+yai3pamw3PeX0fAICCC4T6yZ+1XmfXiN2MHUs7e58mpZWRZF9jdS7xoRGbm1nwxt92xpacY8QGpd7v0X1QPxWOL+onfjYIAOe5mOhw20kR+J/qz32hhMQUX6cBAAAAFCmOvAIASJLWDm7t6xQK5VBSqvOIq9l9XlGFqLOn8C0dtsYY/1jsZ0ZsclwHj+Y0+eKF5n5335Xv7WS/bQAAAMD5hskrAICk4tVPqUJUki6MPua8XibMvG1hJywj5un7oFQR7AMAAAAo7pi8AgAAAACggIrDiWLO9Lk6I7eT4KSVchjrerqlwQk398EXgucXJq+Ksd87PWnELpn3pg8yASBJ168eZsZ8kMf5oHTYGpejrbI3Ic3y8v1tbdZ0r+Hovt4PGbHq06cZsXY3bTFi/wwyf6646bvGRqzpbWd/JphkRUoqXKPS59O6FGp9fzG35hQj1nnPoz7IBMUV9RPgXwKhfioeP+138yQ4j0UbY5qPXubZVB4qbYQ+sNnHO9/+z4hlr5+ylHlpYYFToX7yHzRsBwAAAAAgHzjhje890uZyHQ3jeJzzBY80AAAAAAAFEOgnvLGT20lwjjxrHvdW/Y3Rbm037plnjVjshFeM2P96jjRiMXXjnJf/Ubh6Ou5wa58oPpi8AgAAAACgAIp736VzT4ITlGH293L3PkjLdG/dg+lpRuxCnXRrHyi++NkgAAAAAAAA/BZHXgWgNsEzjNi36Q8YseLSXLSvY64Re9vq7INMfGdI0Dwj9nJGpwJvr7fjIyO2ODTOiDVKr2jEvs7o5dY+bguaZcS+yOjp1rpPOczbe8iRbsS6XHrYiKWmhhmxI8cijNj8xAwj9n16b7fyuzlopsv1RjK/MbJ7fLZ16G/Ejh+LMmItlr/kVh6Fces5t0GSqmWWNGL+9Frrb/O8mGjZvw4ei/1MYScs53W75uzl3/vGiB0febsRO/pnBSP22+bLjVipQR2N2KW3mc/RkOpHjFi7sZ8YsSX1Jp7NoWSwdKMx5LwUaM1F4T+on/zrPb0oUD9RP3laca6fOpf40Hk5rZTD2Zj9yLPXuxxt5Q/1U1paaWndmcstv+rrcvRW9vopyx3ef2r4veJQP3HkFQAAAAAAAPwWk1cAAAAAAADwW0xeAQAAAAAAwG8xeQUAAAAAAAC/5bAsy8p7GDwlPj5esbGxkqS4uDhVqVLFxxkBgWvyBe8bsceO9PBBJgX32SVvGLEOvz/lg0wCX0JiipqPXiZJWju4dZ6nbbZrLpox4Fcj9mfHu43Y4QPljFi9a7YZse8/u96IXX/zOiNWZcrMnNKUlP/bBs/gM9t/8FgAnkP9hLzkVnf4Q/10yBGuu6Nvt80Pvuetz2yOvAIAAAAAAIDfYvIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt4J9nQCQXS/HR0ZsptXFiL1bcYYR63PoAa/kVByNLTnHiA1Kvd8HmRTO7qNhPtlvP8c8l+uvWZ0KvC2ai/rO0T8rmDGb5qLVPvnUiNUYd7kRCyp52ojdcPsaI1Z50gfupggfeer/X+Mn9K+PMwHcQ/1UNKifCof6qXjwh/opKDFF+v+G8vAf3q6fOPIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt5i8AgAAAAAAgN+iYTtsDS4xz4iNzix4U0V31Q5xb5xdc9HpMdONWO+E3oVNqVgKxOaidiYUotFnYRSmwSh8Y1/vh4zYb5vNpqEhoWbTULvmopkD/2fEUp5rZsSOHShrxCrnmKWrpVePc14+GhYsXV/XzTVRWG/8/2s8Pj5eM2If93E2CCTUT8Ub9VPhUD8FprhnnlVaZqrzeiDVT1nabRro5tooDG/XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBv0bAdtoqiuaidfacdBV6X5qIIRJPKvm/EnjjawweZFG/Vp08zYqUGdTRiGafMrsdBJc0mpHbNRcPGrDNi5WzG/fWw2TC56tQZRix7c9GExBRp9DJjTKAa4DCbWo/3o0a+Wfkd178+zgSBhvoJKBrUT0UndsIriokOd173h/rpkCNcKnubbb7FuTn7+V4/ceQVAAAAAAAA/BaTVwAAAAAAAPBbTF4BAAAAAADAbzF5BQAAAAAAAL9Fw/YANKiE2ahtrE2D0E23DDJiV3811q19dHXMMWIfWve7tW5hvGt1LvC6I0LmGrGhpwu+veLs9ejZRuzpxG4+yKRwnrd5LYzyQbPcOdWnGLH79z3q1rpBJSxPp+NRgdoQdfLFC1XqxNn7tt1NW4wxl9522IgtGGu+Z9xw+xojduxAWSNm11zUrglpqdfrmAmfZwrTXPTtcrOMWN9/exYmHUNWfvHx8Zoa+7hHtw3foX6yR/3kPuonz6J+8i9jS559/zpRyiE9VFqS9L+eI3UwPc25zB/qp9OZkdIxY0ixd77XTxx5BQAAAAAAAL/F5BUAAAAAAAD8FpNXAAAAAAAA8FtMXgEAAAAAAMBvOSzL8u9ud8VMfHy8YmNjJUlxcXGqUqWKjzOCN3S3adj6QRE0bIU9uya9iTZvfVNsGt72cnxkxCLlcLn+ViEa5a66brgRu371sAJvz11POcz75I1CNIH0BwmJKWo+epkkae3g1oqJDncu+2dQR2P8BTf8YcT+XtTQiFWZMtOt/f/18ANGrFytBCN2+ukdRmxhzeeNWEpqiPNyUmQJvX3/BZLM21YUxkd8aMQGnOxapDn4Ap/Z/oPH4vxA/eRfqJ9MxbF+spO9pvrC+lgX6qRzmT/UTwcTy6jdqyMkSf0XHFT0yUznsuz1UxZPNyZ3F/WTZz+zOfIKAAAAAAAAfovJKwAAAAAAAPgtJq8AAAAAAADgt4J9nQAAAAAAAPA//8i1z2ZaWmljzCGH2YszKDHFre3brXs6M9KIpSeWcV4+fPxsDsfDXY/HSQ0yj89JcDMXTztRymHEfJXLuYq6f6on0LC9iNFwFAC8I7eG7UuvHmeMb7dpYJHllt3Mi6YZsbv2jDJiyf+51nn5kCNcHUrdKck3DdvdNTHKbEza/3jgNiblM9t/8FgAQNHJXlOheNo35javbZuG7QAAAAAAwKtiosO9OrkB36v+3Bd+cxSYu/jZIAAAAAAAcDFm1R9GrOVXfX2QifRxo4+cl4+Hl9C0WytIkmb3eUUVopKcy06+1NhYt9LI17yeX2G8W/czI9bnjw5e2dehpFS1f+tHr2zb25i8AgAAAAAALsqmpRsxX7UuiD6ZaRuvEJWkC6OPOa8nW+bRRP7abiFLVLLZycnfc/YFfjYIAAAAAAAAv8WRV37u07pvGrG98RcYsWeSA7chLvLmT82m59acYsQ673nUB5lIr0fPNmJPJ3bz+n7PbUrtbkPqD6u9Y8S6/vmIR3LKL1/dd77S9Dbz8Ogl9SYasTu29Xdre4V5Taakhhix7M3Zs0S++oPzckRiGenVO93avi+dSA3ydQqAJOonnEH9ZI/6qeCon/yjfsp+RsGTLzV2Odoqe/0UKKif3MORVwAAAAAAAPBbxW7yyrIsffrpp2rVqpViYmIUERGhunXr6pFHHtGePXuM8UlJSfrPf/6jatWqKSwsTNWrV9ezzz6rEydO+CB7AACAokf9BAAA/Fmxm7waMGCA7rnnHv3xxx+666679OSTT6pGjRp699131aBBA23fvt05Njk5WS1bttTEiRN1ySWXqH///qpbt67Gjx+v1q1bKzU11Ye3BAAAoGhQPwEAAH9WrHpeHThwQK+99pqqVaumn3/+WdHR0c5lEydO1H/+8x+9+uqrmj59uiRp3Lhx2rp1qwYNGqQxY8Y4xz733HP/196dh0dZ3f0f/0y2ScgqCBJMCBCD0ApFFBEBWSxglYI+/KhIoUEFBKSlgLJVRORRQBGsWsGlCIoCbrhWQUUWMbJfiFYBESRBJKgkIRFCIOf3B09GxjNAApmZO5n367q8mnzvM3N/Z05CPj1zzxlNnz5ds2bN0vjx4wP+OAAA5ya3wPv/PBeYWGvMwWj7T+C+fPsTanw56D772xbE2q8b5brsT5SpkZ/k+frAoYRfxhY4d2GgKM5l1Xw9L3yCjrOQnwAAgNO5jDH25zJWUZ9++qnatGmjvn376oUXvDcE3LFjhxo3bqzu3bvrrbfekjFGKSkpKigo0Pfff6/Y2F/+j01RUZHq1q2rOnXqaOfOnZXaY05OjlJTUyVJ2dnZSklJOe34FVdNsWodP5lYqT2di/dbTbNqXdaPC0InAIJp4x/GWrXL3p0e0B725R9Wm6nLA3pOnJ3d0663aquvnmzV2q+aFIh2Tqmif7OrKvJT4JGfAEjOyE9V0cmZL2t85zO+KJZX3MiqJbntt8R/2PoBq3bN2gln2WVgVDQ/VfS5Oxv+yk/V6sqrjIwMRUVFac2aNSooKFBCwi+vVL/99tuSpGuuuUbSiTD23XffqVu3bl7BS5JiY2PVtm1bLV26VNnZ2Z4nvjxycnJOe3zfvn3lvi8AQPklJ8Zo97Tr1WDcO8FuBWfQYNw7fgtMqDjyEwAAcLpqtXhVq1YtTZs2TaNHj1aTJk3Us2dPJSQkaMuWLVq+fLmGDRum4cOHSzoRvqQTgc2XjIwMLV26VDt27KhQ+KrIWABA5csa3znYLVS63IIj6vmvEx9XvWDQQ6odX+A5luBeY43/+I+PW7V2bw33X4PldPLjgHOQnwAAgNNVq8UrSRo5cqQuvPBCDRw4UHPmzPHU27Vrp759+yoi4sRDzs/PlySvfR1OVvaqY9k4AEDVUN2v5qkdX6ALEvM83ye57cdbs7jEqlX35wXnhvwEAACcrNp92uB9992nfv36acKECcrOztahQ4e0evVqHTlyRB07dtSbb77p1/NnZ2ef9r9169b59fwAAAAVRX4CAABOVq2uvPrggw80adIkjRw5UuPG/bLpZbt27fTWW2+pUaNGGj16tHr06OF5xfBUrwwWFJx4S8apXlk8lcrezNXX5qJzk+datVv33Vqp5y0vNhetPsaHLbZqU0tvCkInvr3a2H4bVK/twX8bFE4I1uaiobjRaYJ7jdfVVr42Ib1mrb0JqdMFe3P2UEZ+CjzyU/VBfsK5ID8Fhq/N2clPVU+1uvLq3XfflSR16tTJOla3bl01adJEX3/9tQoLCz17NZTt3fBrZ9rTAQAAoDogPwEAAKerVotXR48elSQdOHDA5/EDBw4oLCxMkZGRysjIUL169bRmzRoVFRV5jSsqKtKaNWvUsGFDNhAFAADVGvkJAAA4XbVavGrbtq0kaebMmdbl7HPmzFFOTo7atGkjt9stl8ulgQMHqrCwUFOmTPEaO2XKFBUWFmrQoEEB6x0AACAYyE8AAMDpqtWeV71799bs2bO1atUqNW7cWD169FBSUpI2bdqk5cuXKyYmRjNnzvSMHzNmjN544w1Nnz5dmzdvVsuWLbVp0yYtW7ZMrVq10t///vfgPRgAAIAAID8BAACnq1aLV+Hh4Vq2bJlmzZqll156SS+++KKOHj2qCy64wPMJOk2bNvWMj42N1cqVK3Xvvffq1Vdf1UcffaTk5GSNHj1akyZNUkyMMz9WPFibi6J6c9Lmor742lz0/qiFVu0fR28ORDsBt6D+U1bt/Fr2hsnXbr4rEO04RnXeXPRUPv7j46pZXOL53tfmor42Id3W3f7daP3+/ZXbHKok8hNw9shPzkZ+8i3U8tOHrR+wauSnqqdaLV5Jktvt1rhx47w+Led0EhMTNWvWLM2aNcvPnQEAADgT+QkAADhZtdrzCgAAAAAAANULi1cAAAAAAABwLBavAAAAAAAA4FjVbs+r6mbO+fOt2pAfMoPQSfXxz8QFVm1Efr8gdIJzVV03F/Wl8Ge3VYutYdcWp8+2ajftHOqXnpzqAbe9Ee2E4urzs9LureFKTjz9hti+Nhe9+G37eXm/VbxV67K+fHseOcnuWwdatQZznynXbdd3G2/VWi2des49IbjIT5WP/FR9kJ/IT75U5/x0zdoJ5RoXavkpe/RdKi494lVzcn7iyisAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsdiw3eHYXLTysbkoqiL+LSi/yy7JDnYLQdf6/futmq/NRVt9/JSPW5/9hqOf3TDKqjV/feZZ399LFz1h1f709TCrVt7NRX1hc/bqiX8zKx/5CVUR/xaUH/kp9PJT6sMPnfFDgE4lGPmJK68AAAAAAADgWCxeAQAAAAAAwLFYvAIAAAAAAIBjsXgFAAAAAAAAx2LD9ipoQX17g7h+ewYHoROgevnv//ubVfvNK4+GbB9VVbeNY4LdgiN1We9rI1G7llfcyKptvHqgVbtm7QSrdi6bi/ria3NR4GyRnwD/cEpucUofVRX5yTfyk3Nw5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWGzYXgWxuahvD8e+YNVqRB+zakN/zPR7L2Nci63ag+Ymv5+3sk2JXGTVJpb08ft5g7Wprq9NPceH2XM5tdS/c8nmotXbjBr2v1V3/vznIHTim6/NRS9b9YyPkfaGo4CTkZ98Iz9VPvIT+QmV7+T8VBjnkm5NDGI3NvKT/3HlFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYbNgOrbhqilXr+MlEq7bjz0OtWsYLs/3S09kYXeScDY+r4uaivgRic1FfArG56POpT1u1/tmDrJq/NxdF6HHS5uy+XLPW10aidi2vuJFVS3J/44eOAGciP1U+8tO5IT+hOjs5P+3LP6x5U5cHsRsb+cn/uPIKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCw2bIeWfdrYqt0V+aRVW19iby462rXYqj1cBTfbnBK5yKqVd7PNp+s8a9Ve/sket+zYLRXuq8z06Bet2tgjfc/6/sqrd9gCq1bfRFq1c5nzF9Lsn7U/f3u7VRvssufoKXP2G6L62lzUl+vC51m1/xwf4PX9uczP2DD7d+ii83+2aoNy7Z+fx897zqoNP/gXq1ben29fvUyv5A1XZ8W/YNVGHrI3C54UYfc8+VhwNsANBF/PS+GRcM/XRXEu6fa4Sj/vZzeMsmrNX59Zrtv62lzU1yakWa2Heb4+6I6QOmVIkp5r9ooSiko9x77Pd1u33VpaYtVeK+1v1fqG2c9fsrEjTlX8+wTnIj+Rn06F/ER+Ij8FztMXL1F8kfF8f3J+KlPZH6IQ6PxUZnd2bat2LvlpeOoSuQuNV83J+YkrrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHchljzJmHobLk5OQoNTVVkpSdna2UlJQgdwQAcLp9+YfVZupySVLW+M5KTowJcke+vdtihlVrs/YJz9f785PUbeYUSc5+HGX4m+0czAUAoExVyUXldab8VMbXZu8VFYjnzl9/s7nyCgAAAAAAAI7F4hUAAAAAAAAci8UrAAAAAAAAOFZEsBsAAADll1twJNgtnNJBtx0r9ucneb4+cCjB87WTH0eZ/QWHg90CAAAAxOIVJN0ftdCqfVD6s1X76NhtVm1i+CKrNuV4n8pprIpYUP8pq9Zvz+BKPcdjSc9btb/m9a/UcwTLq40ft2q9tg+3aiNdi63aLHOTX3o6We+wBVbt5dJ+Xt9X9vyU92dqbvJcq1Z8NNyqXfLb3Vat/apJVu2+SPv3+Z4S+/f5vUsfsmrXbr7Lqvkyu9Z8qzb0x8xy3dbp7vTxMzrDDz+jPf/1SaXfZ6XplGHX/m+D9l9z9OP4P8cKfgh2C3Aw8tO5IT+dG/KTjfxUNQUqPznZ7uzaVu0PPjZnzytuZNWeTPxfq1anpv3i2y3f2X+LxqS+qehD3p/fV9fHe/N8/X36sPUDVu2atRPsG1ci3jYIAIDDJSfGaPe064PdBgAAABAUXHkFAEAVkTW+c7BbOK3nmr1i1f6y9f95vs4tOOK54mrBoIdUO77Ac2zBb+xXn89Pst9a+KeN9qt/Y1LftGq1XXZ/d+3pYdU+/qN99UK7t05cvbB12051m23fDwAAAAKLxSsAAKqI5MSYYLdwWglFpVbtVD3Xji/QBYl5nu/jCo01JiGqfPf360veJSnWx7Xlvm5bs7jklOO+i3PbdwIAAICA422DAAAAAAAAcCyXMcZ+uRJ+k5OTo9TUVElSdna2UlJSgtyR9NJFT1i1P309LAidAKgKfG2IWrt2nlXrtnFMALoJLauvnmzVfG0eGyyTIuxNaycf++VtfvvyD6vN1OWSpP7PFHhdbXV7/t3WbZN8bFbqy6z4F6zayEN/LtdtT2fjf3fo8t82luScv9mhivwEoKojP1Wek/NE1vjOZ7wyvarnpzLTo1+0ahXNTyc/d7fOy1d8kfdyUGXkJ3/9zebKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxIoLdAIIv1DYXvTt8sVX73+M3BaGT4BkfZj8HU0ur73Mw1GVvgjjb2JsgBkN5N2h0kn57Blu1J2o+d9b390jCAqt2+Gi4VRt/5Gar9kzdZ63awO9vOetenK6yNxet7A2nt5aWlHvs+UlHlBBV6vne1+aiecWNrNqs2AesWka9onKf99emRNq/gxNLnP07CGcgP5GfJPJTsJCfyE8VUV3yU52ah61aRfNTUZxLGhInSaqV+LMST8piFRGM/MSVVwAAAAAAAHAsFq8AAAAAAADgWCxeAQAAAAAAwLFYvAIAAAAAAIBjuYwxJthNhJKcnBylpqZKkrKzs5WSkuK3c229caRVa7Zklt/OB+D0nq5jb445KLf6bo55LhY1mmPV+nwzxDH3V16za823akN/zPT7eZ1qX/5htZm6XJKUNb6zkhNjTjve14a8I4smWDVfm5XOTZ5r1W7dd2u5+ny/1TRJ0g4V6o4N90vy/99snB75CQhd5KfyC5X8VNE8EWpOl5/25yep28wpknw/d5WRnw4czdefPzvxdWX+zebKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgRwW4AAAAAAACgonILjgS7BccpinNZtf35SZKkA4cSPDVfz11BDfv6pn35h8t13p/cJ5aX8hRervEVxYbtARbIDUeBczXYZW/295Tp4/fzPhjzolUbc7iv388bDFOjF1q18UduDkIn5e9lSqT9c5Fcy/6jNvD7s99MdVb8C+UaN/LQn8/6HKFm960DrVqDuc9U6jn6htnz9mLpL3N08gar7Z8oVPShXyLIb+KOW7etfV6RVeu3Z7BVyytuZNU2tB9k1X6/brxV2953mFWLiimWJG09fFw9Fp7YNJa/2cFFfkJVQn7yP/KTb6GSn07OE3CeYwU/aO/sAZLYsB0AAAAAAISg5MQY7Z52fbDbQIDxtkEAAAAAAFClZI3v7PdzZI++y6qlPvxQpZ5jeOoSq/Z49o1WbUzqm1Yto4Z95XqtxJ+t2v+sO3G1XW7BEfX81yeSpAWDHlLt+AKvcVt62Vdrtn/7Dqv2zfB/WLXI6KOSpG0/l+gv1tFzx+IVAAAAAACoUpITY/x+juJSe1+oyj6vu9DeycnXOU7ebqFMvI9doBKjSst1f7XjC3RBYp5XrWZxSblue+i4/bxElZ7YdmG/sRfUKgNvGwQAAAAAAIBjceUVNO9Ce8PeVd/FWrW5xt548Kna86za4AMDKqOtKuP9VtOsWpf14yr1HK82ftyq9do+vFLP4UsgNhddffVkqzbm8CSr5msDykBsNnmna7FVm2Fu8vr+XObH14ae5f2Z+s/vHrZq120ZbdUWNZpj1fp8M6RcvfgysaR8Pxc7/3K7Vft8Y1Or1vOLv1s1X3O7oP5T5TovfKvszdl9STbljxW1XVLsSS+hlff3eW7yXKtWP9XenP3y1U9btR/HbbJqn6zsZtU6X79GkhTmsl+5BMqQn84N+enckJ/IT+SnwHBSfqrr49KjiuanghphUu/akk68RfDXV1o5OT9x5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWC5jfHy2IvwmJydHqampkqTs7GylpKQEuSMAAAJjX/5htZm6XJKUNb6zXz/i+sdxva1a+OSN9rjBXazaf95oJ0nKiT6oB/ePkMTf7GAjPwEAcO7OlMWcnJ+48goAAAAAAACOxeIVAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwrIhgNwAAv/ZigzlWre/uIUHoxP8W1H/KqvXbMzgInZTfvAufsWoD9g70+3lfuugJq3beeQVWrcv6cX7vpSpa3228VWu1dGoQOjnh4z8+rprFJZ7vr1k7wRozJXKRVZtY0seqbe87zKp9srKbVWu/r6ZVq/XU+1atYGFHSVKhwq1jAOBU5Cfyky/kp3PjpPz0YesHrNq55Kdvhv9Dh44f8ao5OT9x5RUAAAAAAAAci8UrAAAAAAAAOBaLVwAAAAAAAHAsFq8AAAAAAADgWC5jjAl2E6EkJydHqampkqTs7GylpKQEuSPg1Aa4Flq1eeZmv5/3/ij7vP846v/zhrr3W02zaueyeefsWvPLNW7oj5lWbXr0i1atdcudVq3jJxMr3lgF/c212Ko9am6yanf6GDfDx7hQti//sNpMXS5JyhrfWcmJMRW+D18/pxnNd1i1sPBSq/bGS52tWsHP9mfX3HHoH5KkLV/WUMdLv5DE3+xgIz+hKiE/hRbyk2/kJ2cp+zn9yR2hse2aSpJe+vFd1Sk97DXOyfmJK68AAAAAAADgWCxeAQAAAAAAwLHsa73gV8eOHfN8vW/fviB2ApxZkX60ajk5OX4/b74JznlD3YGj+VbtXJ73g6U/lWucr3P4+hk4UFy5/ZVXYTl/Dw4F6felKtlfcFjHCn6QJG3dtlPfxbkrfB87VGjVjhw+btXCXPZl7znRB61aocKt2pYva0iStn8T5amd/PcbgUd+QlVCfgot5CffyE/OUvZzmqdwTxbb9nOJ9hvvDOXk/MSeVwG2fv16XXHFFcFuAwAAVMC6devUqlWrYLcRsshPAABUPZWZn3jbIAAAAAAAAByLK68C7MiRI9q6daukE5fQXXXVVZJOrEgmJycHs7WQtm/fPs8rusxF8DEfzsJ8OAdzEVjHjh3TgQMHJEnNmjVTdHR0kDsKXWX5af/+/frjH/8oid8BJ+DfJGdhPpyDuXAW5iOw/JWf2PMqwKKjoz2XzZ38Xt7k5GQ+9tkhmAtnYT6chflwDuYiMBo0aBDsFqBf8hPZybmYD2dhPpyDuXAW5iMw/JGfeNsgAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxWLwCAAAAAACAY7F4BQAAAAAAAMdyGWNMsJsAAAAAAAAAfOHKKwAAAAAAADgWi1cAAAAAAABwLBavAAAAAAAA4FgsXgEAAAAAAMCxWLwCAAAAAACAY7F4BQAAAAAAAMdi8QoAAAAAAACOxeIVAAAAAAAAHIvFKwAAAAAAADgWi1cAAAAAAABwLBavgmT9+vW67rrrlJSUpNjYWF155ZV66aWXgt1WtbR371498sgj6tq1q+rXr6+oqCjVrVtXvXr10tq1a33epqCgQKNGjVJaWprcbrcaNGigu+66S4WFhQHuPnRMnz5dLpdLLpdLn376qXWcOfG/JUuWqEuXLqpVq5aio6PVsGFD3XzzzcrOzvYax1z4jzFGr732mjp16qTk5GTVqFFDF198sW6//XZ988031njmAqGG/BQ45CfnIzsFH9nJGchPIcIg4JYvX24iIyNNfHy8GTRokBk1apRJS0szksyMGTOC3V61M3bsWCPJpKenm9tuu82MGzfO9OrVy4SHh5uwsDCzaNEir/GFhYWmRYsWRpLp2rWrGTt2rOnatauRZFq1amUOHz4cpEdSfW3dutW43W4TGxtrJJmsrCyv48yJf5WWlprBgwd7fk+GDRtmxo4da/r372/q169vVq9e7RnLXPjXqFGjjCSTnJxshgwZYsaMGWO6detmXC6XiY+PN1u3bvWMZS4QashPgUV+cjayU3CRnZyF/BQaWLwKsJKSEpOenm7cbrfZvHmzp56Xl2caN25soqKizO7du4PXYDX06quvmhUrVlj1VatWmcjISHPeeeeZI0eOeOr33HOPkWTGjh3rNb4sxD3wwAN+7zmUHD161LRs2dK0bt3a9OvXz2cAY07865FHHjGSzLBhw8yxY8es4yUlJZ6vmQv/2bdvnwkLCzNpaWkmLy/P69jMmTONJHPLLbd4aswFQgn5KfDIT85Fdgo+spNzkJ9CB4tXAbZ06VLrF6jMvHnzjCQzefLkIHQWmspW2devX2+MOfEqSr169UxcXJwpLCz0GltYWGji4uJMo0aNgtFqtTVp0iTjdrvNF198YTIzM60Axpz4188//2zOO+8806hRI6+g5Qtz4V9ZWVlGkunbt691bPv27UaS6d69uzGGuUDoIT85C/kpuMhOwUV2chbyU+hgz6sAW7FihSSpa9eu1rFu3bpJklauXBnIlkJaZGSkJCkiIkKStGPHDn333Xdq27atYmNjvcbGxsaqbdu2+uabb6z3sePsbNq0Sffff78mTZqk3/zmNz7HMCf+tWzZMh08eFA33HCDjh8/rtdee03Tpk3TnDlz9PXXX3uNZS78KyMjQ1FRUVqzZo0KCgq8jr399tuSpGuuuUYSc4HQQ35yFvJT8JCdgo/s5Czkp9DB4lWA7dixQ9KJX7Jfq1u3ruLi4jxj4F979uzRBx98oOTkZDVr1kzS6efn5DpzdO6Ki4v1l7/8RS1atNCYMWNOOY458a+NGzdKksLDw9W8eXP16tVL48eP19ChQ3XxxRfrzjvv9IxlLvyrVq1amjZtmvbs2aMmTZpo6NChGjt2rK699lqNHTtWw4YN0/DhwyUxFwg95CfnID8FD9nJGchOzkJ+Ch0RwW4g1OTn50uSEhMTfR5PSEjwjIH/lJSUqH///iouLtb06dMVHh4uqXzzc/I4nL177rlHO3bs0MaNGz3Pvy/MiX/l5uZKkmbOnKmWLVtq3bp1atq0qTZv3qzBgwfr4YcfVnp6uoYOHcpcBMDIkSN14YUXauDAgZozZ46n3q5dO/Xt29dzlQNzgVBDfnIG8lNwkZ2cgezkPOSn0MCVVwg5paWlGjBggFatWqVBgwapf//+wW4p5GRlZWnGjBm6++67dckllwS7nZBWWloqSYqKitLrr7+uVq1aKS4uTu3bt9fLL7+ssLAwPfzww0HuMnTcd9996tevnyZMmKDs7GwdOnRIq1ev1pEjR9SxY0e9+eabwW4RQIgiPwUX2ck5yE7OQ34KDSxeBVjZKu+pVnMLCgpOuRKMc1daWqpbb71VL774ovr16+e1Mi+Vb35OHoeKO3bsmDIzM9W8eXONGzfujOOZE/8qe94uv/xy1atXz+vYJZdcokaNGmnnzp3Ky8tjLvzsgw8+0KRJkzR8+HCNGzdOKSkpiouLU7t27fTWW28pMjJSo0ePlsTvBUIP+Sm4yE/BRXZyFrKTs5CfQgdvGwywk99He9lll3kd+/7771VYWKgrrrgiGK1Ve6Wlpbrlllv03HPP6eabb9a8efMUFua9fnum9zmf6X3SOLPCwkLP8xgVFeVzTJs2bSRJS5Ys8WxGypz4x8UXXyxJSkpK8nm8rH748GF+P/zs3XfflSR16tTJOla3bl01adJEmzdvVmFhIXOBkEN+Ch7yU/CRnZyF7OQs5KfQweJVgHXo0EFTp07VsmXL1KdPH69jS5cu9YxB5To5eN100016/vnnfe4VkJGRoXr16mnNmjUqKiry+hSKoqIirVmzRg0bNlRqamog269W3G63brvtNp/HVq1apR07dqhHjx6qXbu2GjRowJz4Wdkf+i+//NI6VlJSoq+//lqxsbGqXbu26taty1z40dGjRyVJBw4c8Hn8wIEDCgsLU2RkJL8XCDnkp+AgPzkD2clZyE7OQn4KIQYBVVJSYho1amTcbrfZvHmzp56Xl2caN25soqKizK5du4LWX3V0/Phxk5mZaSSZ3r17m5KSktOOv+eee4wkM3bsWK/62LFjjSTzwAMP+LPdkFY2T1lZWV515sS/unbtaiSZp59+2qt+3333GUmmX79+nhpz4T8LFy40ksxvf/tbk5eX53Vs9uzZRpJp27atp8ZcIJSQnwKP/FQ1kJ2Cg+zkHOSn0OEyxpjALJOhzEcffaRu3bopOjpaffr0UXx8vF599VV9++23mjFjhuc9uagc9957ryZPnqy4uDiNGDHC82kTJ7vhhhvUokULSSdW3du2bastW7aoa9euatmypTZt2qRly5apVatWWrlypWJiYgL8KELDgAEDNH/+fGVlZenKK6/01JkT/9q5c6euuuoq5ebm6vrrr/dcXr18+XKlpaXp008/Vd26dSUxF/50/Phxde7cWatWrVKdOnXUo0cPJSUladOmTVq+fLliYmK0YsUKz1ujmAuEGvJTYJGfqgayU3CQnZyD/BRCgr16FqrWrl1rrr32WpOQkGBiYmLMFVdcYRYtWhTstqqlslekTvffs88+63WbvLw88/e//92kpqaayMhIU79+fTN69GhTUFAQnAcRIk716qExzIm/7dmzxwwYMMDUrVvXREZGmtTUVHPHHXeY/fv3W2OZC/85cuSImTp1qrn00ktNjRo1TEREhLnwwgtNv379zH//+19rPHOBUEN+ChzyU9VAdgoespNzkJ9CA1deAQAAAAAAwLHCzjwEAAAAAAAACA4WrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQBUEQMGDJDL5dLu3bv9do4GDRqoQYMGfrt/AACAQCI/AdUDi1cAyqWoqEgPPPCAWrZsqbi4OLndbqWkpKh9+/YaP368du7cGdB+AhFEAAAAzgX5CQAqR0SwGwDgfIcOHVK7du302Wef6aKLLlK/fv1Uq1Yt/fDDD1q3bp2mTZum9PR0paenB7vVam3q1KkaN26cLrzwwmC3AgAAzoD85AzkJ6B6YPEKwBk98sgj+uyzzzRw4EA99dRTcrlcXsd37dql4uLiIHUXOpKTk5WcnBzsNgAAQDmQn5yB/ARUD7xtEMAZZWVlSZLuuOMOK3hJUsOGDdWkSROrnpubq5EjR+qiiy6S2+3W+eefr169eunzzz+3xpbtFVBYWKgRI0aoXr16crvdat68uV555RVr7Pz58z3ndrlccrlc6tixo9e4Xbt2aeDAgapfv77cbreSk5M1YMAAffvtt9b5y26/f/9+ZWZm6vzzz1dMTIyuvPJKrVixwufzcujQIU2ePFnNmzdXjRo1lJiYqEsvvVQTJ05USUnJWfdyKr4u9V+xYoVcLpfuvfdebdiwQV26dFF8fLwSExN14403nvJtAW+88YZatWqlmJgYXXDBBRo0aJAOHjx4ynMfPXpUM2fOVMuWLRUbG6v4+Hi1b99eb775pte4adOmyeVyaciQIdZ9lB0bOnRouR8zAABVFflphc/nhfxEfgLOhssYY4LdBABn69+/vxYsWKDFixfrT3/6U7lus3PnTnXs2FE5OTnq2rWrmjVrptzcXL366qtyuVz68MMP1bp1a8/4Bg0aqKSkRGlpaTp48KB+//vf6+eff9aiRYt0+PBhvffee+rataukE69kzps3T1u2bNGIESOUlJTkuY8BAwZIktauXatu3bqpqKhI3bt3V0ZGhnbv3q0lS5aoZs2aysrKUqNGjTznd7lc+t3vfqeioiIlJiaqffv2ys3N1eLFixUeHq6NGzfqkksu8YzPzc1Vhw4d9NVXX6lFixbq3LmzSktL9dVXX+nDDz9Ubm6up6+K9nIqAwYM0Pz587Vr1y7PpqArVqxQp06ddN111+mjjz5Sp06d1LRpU23evFnLly9Xenq6Pv/8c0VHR3vu57nnnlNmZqYSEhJ00003KSkpSW+//bZiYmK0b98+RUVFeYW24uJiXXvttVqxYoVatGih9u3bq6SkRO+8846ys7P12GOPafjw4ZKk0tJSdenSRcuXL9eSJUt0ww03SJLWrVundu3aKSMjQxs2bFBMTEy5fo4AAKiqyE/kJ/ITUIkMAJzBG2+8YSSZ+Ph4M3r0aLN06VLzww8/nPY2V111lQkPDzfvvfeeV33btm0mPj7eNGvWzKuelpZmJJmePXua4uJiT/2DDz4wkky3bt28xmdmZhpJZteuXda5jx49aho0aGDi4+PNpk2bvI6tXr3ahIeHm+7du3vVJRlJZtiwYeb48eOe+jPPPGMkmdtvv91rfK9evYwkM2HCBOv833//vSkpKTnrXk7F12P+6KOPPL0vWrTIa3z//v2NJLNw4UJPLT8/3yQkJJjY2Fizbds2T/3o0aPm6quvNpJMWlqa1/1MmDDBSDITJ040paWlnnpBQYG5/PLLTVRUlNm7d6+nnpOTY2rVqmVq1qxpcnJyTEFBgUlPTzdut9ts2bKlXI8VAICqjvxEfiI/AZWHxSsA5fLwww+buLg4zx96SSY9Pd3ccccdZvv27V5jN23aZCSZW2+91ed9jRo1ykgyW7du9dTKwtc333xjjU9LSzM1a9b0qp0ufL322mtGkrnvvvt8nv9//ud/TFhYmMnPz/fUJJnY2Fhz6NAhr7ElJSUmIiLCtGzZ0lPbt2+fcblcJj093Rw9etTnOc6ll1M5Xfi6+uqrrfFlx0aNGuWpzZ8/30gyf/3rX63xq1evtsLX8ePHzXnnnWfS09O9gleZN99800gyjz32mFf99ddfN5JMx44dTb9+/Ywk889//vOMjxEAgOqE/ER+Ij8BlYMN2wGUy6hRozRo0CC99957+uSTT7RhwwatXbtW//rXv/Tvf/9bixcvVo8ePSRJn376qSRp//79uvfee637+uqrrzz/e/Kl5ElJSWrYsKE1PiUlxbNvRHmUnX/btm0+z//999+rtLRU27dv1+WXX+6pN27cWHFxcV5jIyIidMEFFygvL89T27Bhg4wx6tSpkyIjI/3SS0VddtllVi0lJUWSvHrfsmWLJKl9+/bW+DZt2igiwvvPwrZt23Tw4EHVq1dPkydPtm5z4MABSb/MaZmePXtqyJAhmjNnjiTpuuuu09/+9rcKPCIAAKo+8lOep0Z++gX5Cag4Fq8AlFt8fLx69+6t3r17S5Ly8/M1YcIEPfHEE7rtttu0d+9eRUVF6aeffpIkvfPOO3rnnXdOeX9FRUVe3ycmJvocFxERodLS0nL3WXb+F1544bTjfn3+hISEU57/+PHjnu/z8/MlqVwfuXy2vVSUr97LgpSv3uvUqWONDw8PV61atbxqZf1/8cUX+uKLL055fl/933jjjZ7wVbanAwAAoYb8dAL5yUZ+AsqPTxsEcNYSExP1+OOPKy0tTT/88IO2bt0q6Zcg8Nhjj8mceHuyz/8yMzP90lfZ+d96663Tnr9Dhw5ndf9lG4nu3bs36L1UVFnAzc3NtY4dP35cP/74o1etrP9evXqdtv9nn33W63Z5eXkaNGiQYmNjFR0drb/+9a86dOiQnx4VAABVB/mJ/ER+AiqOxSsA58Tlcik2NtarVvYpOBW5VL2iwsPDJXm/Khao819++eUKCwvTRx99ZH2kc6B7qajf/e53kqTVq1dbx7KysnTs2DGvWtOmTZWQkKANGzac8bGebPDgwdqzZ4/++c9/6qGHHtLOnTt1xx13nFvzAABUE+Qn8pMv5Cfg1Fi8AnBGTz75pNavX+/z2Ouvv64vv/xSSUlJnv0XrrjiCrVu3VoLFy7U4sWLrduUlpZq5cqV59RTzZo1JUnZ2dnWsZ49e6p+/fqaOXOmVq1aZR0vKSnRxx9/fNbnvuCCC9SrVy/t3LnT5z4Gubm5nhDj714qqmfPnkpISNDcuXO1fft2rz7uvvtua3xERISGDh2qb7/9VnfeeafPAPb55597vRL573//Wy+//LJ69+6t2267TcOHD1f37t31/PPP68UXX/TPAwMAwGHIT97IT97IT0DFsOcVgDN69913NWTIEF100UVq27at6tWrp6KiIm3evFmrV69WWFiYnnjiCbndbs9tFi5cqE6dOqlPnz565JFH1LJlS8XExGjPnj3KysrSgQMHdOTIkbPuqXPnzpoxY4YGDx6sXr16KTY2Vmlpaerfv7/cbrdeeeUV/eEPf1CHDh3UuXNnNWvWTC6XS99++61Wr16tWrVqWZtkVsQTTzyhzz//XPfff7/+85//qHPnzjLGaPv27Vq2bJn279+vpKSkgPRSEYmJiXr00Uc1YMAAtWrVSn369FFiYqLefvttxcTEKDk52brN5MmTtWnTJj366KN65513dPXVV6tOnTrau3evtm7dqi1btigrK0t16tTR9u3bNWLECKWmpuqpp57y3MfcuXPVvHlzDR06VG3atPG5sSwAANUJ+clGfiI/AWetcj60EEB19tVXX5kHH3zQdOnSxTRs2NBER0eb6Ohok56ebjIzM82GDRt83u6nn34yd999t7nkkktMTEyMiYuLMxkZGaZv377mtdde8xqblpbm9RHDJ+vQoYPx9c/Vgw8+aDIyMkxkZKSRZDp06OB1PCcnx4wYMcJkZGQYt9ttEhISTNOmTc3AgQPNhx9+6DXW1+3P1Ft+fr6ZOHGiadKkiXG73SYxMdG0aNHC3HPPPdZHQFekl1M53Uc9T5o0yRq/a9cuI8lkZmZax5YsWWIuu+wy43a7TZ06dczAgQPNTz/9dMrHeuzYMfPkk0+atm3bmoSEBON2u039+vXNtddea2bPnm0KCwtNcXGxadmypQkLCzMrV6607mPZsmXG5XKZK6+80pSUlJTrMQMAUFWRn8hP5Ceg8riMMSY4y2YAAAAAAADA6bHnFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADHYvEKAAAAAAAAjsXiFQAAAAAAAByLxSsAAAAAAAA4FotXAAAAAAAAcCwWrwAAAAAAAOBYLF4BAAAAAADAsVi8AgAAAAAAgGOxeAUAAAAAAADH+v/zMeuZub9beAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1400x1000 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax_arr = plt.subplots(nrows=1, ncols=2, figsize=(7, 5), dpi=200)\n",
     "\n",
@@ -450,9 +652,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-03-28T12:51:15.033923Z",
+     "iopub.status.busy": "2023-03-28T12:51:15.033812Z",
+     "iopub.status.idle": "2023-03-28T12:51:15.036376Z",
+     "shell.execute_reply": "2023-03-28T12:51:15.036143Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1: The Sane Society is an ambitious work .\n",
+      " 2: Its scope is as broad as the question : What does it mean to live in modern society ? ?\n",
+      " 3: A work so broad , even when it is directed by a leading idea and informed by a moral vision , must necessarily `` fail '' .\n",
+      " 4: Even a hasty reader will easily find in it numerous blind spots , errors of fact and argument , important exclusions , areas of ignorance and prejudice , undue emphases on trivia , examples of broad positions supported by flimsy evidence , and the like .\n",
+      " 5: Such books are easy prey for critics .\n",
+      " 6: Nor need the critic be captious .\n",
+      " 7: A careful and orderly man , who values precision and a kind of tough intellectual responsibility , might easily be put off by such a book .\n",
+      " 8: It is a simple matter , for one so disposed , to take a work like The Sane Society and shred it into odds and ends .\n",
+      " 9: The thing can be made to look like the cluttered attic of a large and vigorous family -- a motley jumble of discarded objects , some outworn and some that were never useful , some once whole and bright but now chipped and tarnished , some odd pieces whose history no one remembers , here and there a gem , everything fascinating because it suggests some part of the human condition -- the whole adding up to nothing more than a glimpse into the disorderly history of the makers and users .\n",
+      "10: That could be easily done , but there is little reason in it .\n",
+      "11: It would come down to saying that Fromm paints with a broad brush , and that , after all , is not a conclusion one must work toward but an impression he has from the outset .\n",
+      "\n",
+      "12: the effect of the digitalis glycosides is inhibited by a high concentration of potassium in the incubation medium and is enhanced by the absence of potassium ( Wolff , 1960 ) .\n",
+      "13: B. Organification of iodine The precise mechanism for organification of iodine in the thyroid is not as yet completely understood .\n",
+      "14: However , the formation of organically bound iodine , mainly mono-iodotyrosine , can be accomplished in cell-free systems .\n",
+      "15: In the absence of additions to the homogenate , the product formed is an iodinated particulate protein ( Fawcett and Kirkwood , 1953 ; ; Taurog , Potter and Chaikoff , 1955 ; ; Taurog , Potter , Tong , and Chaikoff , 1956 ; ; Serif and Kirkwood , 1958 ; ; De Groot and Carvalho , 1960 ) .\n",
+      "16: This iodoprotein does not appear to be the same as what is normally present in the thyroid , and there is no evidence so far that thyroglobulin can be iodinated in vitro by cell-free systems .\n",
+      "17: In addition , the iodoamino acid formed in largest quantity in the intact thyroid is di-iodotyrosine .\n",
+      "18: If tyrosine and a system generating hydrogen peroxide are added to a cell-free homogenate of the thyroid , large quantities of free mono-iodotyrosine can be formed ( Alexander , 1959 ) .\n",
+      "19: It is not clear whether this system bears any resemblance to the in vivo iodinating mechanism , and a system generating peroxide has not been identified in thyroid tissue .\n",
+      "20: On chemical grounds it seems most likely that iodide is first converted to Afj and then to Afj as the active iodinating species .\n",
+      "\n",
+      "21: the statement empirical , for goodness was not a quality like red or squeaky that could be seen or heard .\n",
+      "22: What were they to do , then , with these awkward judgments of value ? ?\n",
+      "23: To find a place for them in their theory of knowledge would require them to revise the theory radically , and yet that theory was what they regarded as their most important discovery .\n",
+      "24: It appeared that the theory could be saved in one way only .\n",
+      "25: If it could be shown that judgments of good and bad were not judgments at all , that they asserted nothing true or false , but merely expressed emotions like `` Hurrah '' or `` Fiddlesticks '' , then these wayward judgments would cease from troubling and weary heads could be at rest .\n",
+      "26: This is the course the positivists took .\n",
+      "27: They explained value judgments by explaining them away .\n",
+      "28: Now I do not think their view will do .\n",
+      "29: But before discussing it , I should like to record one vote of thanks to them for the clarity with which they have stated their case .\n",
+      "30: It has been said of John Stuart Mill that he wrote so clearly that he could be found out .\n",
+      "\n",
+      "31: Greer Garson , world-famous star of stage , screen and television , will be honored for the high standard in tasteful sophisticated fashion with which she has created a high standard in her profession .\n",
+      "32: As a Neiman-Marcus award winner the titian-haired Miss Garson is a personification of the individual look so important to fashion this season .\n",
+      "33: She will receive the 1961 `` Oscar '' at the 24th annual Neiman-Marcus Exposition , Tuesday and Wednesday in the Grand Ballroom of the Sheraton-Dallas Hotel .\n",
+      "34: The only woman recipient , Miss Garson will receive the award with Ferdinando Sarmi , creator of chic , beautiful women 's fashions ; ; Harry Rolnick , president of the Byer-Rolnick Hat Corporation and designer of men 's hats ; ; Sydney Wragge , creator of sophisticated casuals for women and Roger Vivier , designer of Christian Dior shoes Paris , France , whose squared toes and lowered heels have revolutionized the shoe industry .\n",
+      "35: The silver and ebony plaques will be presented at noon luncheons by Stanley Marcus , president of Neiman-Marcus , Beneficiary of the proceeds from the two showings will be the Dallas Society for Crippled Children Cerebral Palsy Treatment Center .\n",
+      "36: The attractive Greer Garson , who loves beautiful clothes and selects them as carefully as she does her professional roles , prefers timeless classical designs .\n",
+      "37: Occasionally she deserts the simple and elegant for a fun piece simply because `` It 's unlike me '' .\n",
+      "38: In private life , Miss Garson is Mrs. E.E. Fogelson and on the go most of the time commuting from Dallas , where they maintain an apartment , to their California home in Los Angeles ' suburban Bel-Air to their ranch in Pecos , New Mexico .\n",
+      "39: Therefore , her wardrobe is largely mobile , to be packed at a moment 's notice and to shake out without a wrinkle .\n",
+      "40: Her creations in fashion are from many designers because she does n't want a complete wardrobe from any one designer any more than she wants `` all of her pictures by one painter '' .\n",
+      "\n",
+      "41: Wage-price policies of industry are the result of a complex of forces -- no single explanation has been found which applies to all cases .\n",
+      "42: The purpose of this paper is to analyze one possible force which has not been treated in the literature , but which we believe makes a significant contribution to explaining the wage-price behavior of a few very important industries .\n",
+      "43: While there may be several such industries to which the model of this paper is applicable , the authors make particular claim of relevance to the explanation of the course of wages and prices in the steel industry of the United States since World War 2 .\n",
+      "44: Indeed , the apparent stiffening of the industry 's attitude in the recent steel strike has a direct explanation in terms of the model here presented .\n",
+      "45: The model of this paper considers an industry which is not characterized by vigorous price competition , but which is so basic that its wage-price policies are held in check by continuous critical public scrutiny .\n",
+      "46: Where the industry 's product price has been kept below the `` profit-maximizing '' and `` entry-limiting '' prices due to fears of public reaction , the profit seeking producers have an interest in offering little real resistance to wage demands .\n",
+      "47: The contribution of this paper is a demonstration of this proposition , and an exploration of some of its implications .\n",
+      "48: In order to focus clearly upon the operation of this one force , which we may call the effect of `` public-limit pricing '' on `` key '' wage bargains , we deliberately simplify the model by abstracting from other forces , such as union power , which may be relevant in an actual situation .\n",
+      "49: For expository purposes , this is best treated as a model which spells out the conditions under which an important industry affected with the public interest would find it profitable to raise wages even in the absence of union pressures for higher wages .\n",
+      "\n",
+      "50: The vast Central Valley of California is one of the most productive agricultural areas in the world .\n",
+      "51: During the summer of 1960 , it became the setting for a bitter and basic labor-management struggle .\n",
+      "52: The contestants in this economic struggle are the Agricultural Workers Organizing Committee ( AWOC ) of the AFL-CIO and the agricultural employers of the State .\n",
+      "53: By virtue of the legal responsibilities of the Department of Employment in the farm placement program , we necessarily found ourselves in the middle between these two forces .\n",
+      "54: It is not a pleasant or easy position , but one we have endeavored to maintain .\n",
+      "55: We have sought to be strictly neutral as between the parties , but at the same time we have been required frequently to rule on specific issues or situations as they arose .\n",
+      "56: Inevitably , one side was pleased and the other displeased , regardless of how we ruled .\n",
+      "57: Often the displeased parties interpreted our decision as implying favoritism toward the other .\n",
+      "58: We have consoled ourselves with the thought that this is a normal human reaction and is one of the consequences of any decision in an adversary proceeding .\n",
+      "59: It is disconcerting , nevertheless , to read in a labor weekly , `` Perluss knuckles down to growers '' , and then to be confronted with a growers ' publication which states , `` Perluss recognizes obviously phony and trumped-up strikes as bona fide '' .\n",
+      "\n",
+      "60: Rookie Ron Nischwitz continued his pinpoint pitching Monday night as the Bears made it two straight over Indianapolis , 5-3 .\n",
+      "61: The husky 6-3 , 205-pound lefthander , was in command all the way before an on-the-scene audience of only 949 and countless of television viewers in the Denver area .\n",
+      "62: It was Nischwitz ' third straight victory of the new season and ran the Grizzlies ' winning streak to four straight .\n",
+      "63: They now lead Louisville by a full game on top of the American Association pack .\n",
+      "64: Nischwitz fanned six and walked only Charley Hinton in the third inning .\n",
+      "65: He has given only the one pass in his 27 innings , an unusual characteristic for a southpaw .\n",
+      "66: The Bears took the lead in the first inning , as they did in Sunday 's opener , and never lagged .\n",
+      "67: Dick McAuliffe cracked the first of his two doubles against Lefty Don Rudolph to open the Bear 's attack .\n",
+      "68: After Al Paschal gruonded out , Jay Cooke walked and Jim McDaniel singled home McAuliffe .\n",
+      "69: Alusik then moved Cooke across with a line drive to left .\n",
+      "\n",
+      "70: Unemployed older workers who have no expectation of securing employment in the occupation in which they are skilled should be able to secure counseling and retraining in an occupation with a future .\n",
+      "71: Some vocational training schools provide such training , but the current need exceeds the facilities .\n",
+      "72: Current programs The present Federal program of vocational education began in 1917 with the passage of the Smith-Hughes Act , which provided a continuing annual appropriation of $ 7 million to support , on a matching basis , state-administered programs of vocational education in agriculture , trades , industrial skills and home economics .\n",
+      "73: Since 1917 some thirteen supplementary and related acts have extended this Federal program .\n",
+      "74: The George-Barden Act of 1946 raised the previous increases in annual authorizations to $ 29 million in addition to the $ 7 million under the Smith Act .\n",
+      "75: The Health Amendment Act of 1956 added $ 5 million for practical nurse training .\n",
+      "76: The latest major change in this program was introduced by the National Defense Education Act of 1958 , Title 8 , of which amended the George-Barden Act .\n",
+      "77: Annual authorizations of $ 15 million were added for area vocational education programs that meet national defense needs for highly skilled technicians .\n",
+      "78: The Federal program of vocational education merely provides financial aid to encourage the establishment of vocational education programs in public schools .\n",
+      "79: The initiative , administration and control remain primarily with the local school districts .\n",
+      "80: Even the states remain primarily in an assisting role , providing leadership and teacher training .\n",
+      "\n",
+      "81: briefly , the topping configuration must be examined for its inferences .\n",
+      "82: Then the fact that the lower channel line was pierced had further forecasting significance .\n",
+      "83: And then the application of the count rules to the width ( horizontally ) of the configuration gives us an intial estimate of the probable depth of the decline .\n",
+      "84: The very idea of there being `` count rules '' implies that there is some sort of proportion to be expected between the amount of congestive activity and the extent of the breakaway ( run up or run down ) movement .\n",
+      "85: This expectation is what really `` sold '' point and figure .\n",
+      "86: But there is no positive and consistently demonstrable relationship in the strictest sense .\n",
+      "87: Experience will show that only the vaguest generalities apply , and in fine , these merely dwell upon a relationship between the durations and intensities of events .\n",
+      "88: After all , too much does not happen too suddenly , nor does very little take long .\n",
+      "89: The advantages and disadvantages of these two types of charting , bar charting and point and figure charting , remain the subject of fairly good-natured litigation among their respective professional advocates , with both methods enjoying in common , one irrevocable merit .\n",
+      "90: They are both trend-following methods .\n",
+      "\n",
+      "91: Miami , Fla. , March 17 -- The Orioles tonight retained the distinction of being the only winless team among the eighteen Major-League clubs as they dropped their sixth straight spring exhibition decision , this one to the Kansas City Athletics by a score of 5 to 3 .\n",
+      "92: Indications as late as the top of the sixth were that the Birds were to end their victory draught as they coasted along with a 3-to-o advantage .\n",
+      "93: Siebern hits homer Over the first five frames , Jack Fisher , the big righthander who figures to be in the middle of Oriole plans for a drive on the 1961 American League pennant , held the A 's scoreless while yielding three scattered hits .\n",
+      "94: Then Dick Hyde , submarine-ball hurler , entered the contest and only five batters needed to face him before there existed a 3-to-3 deadlock .\n",
+      "95: A two-run homer by Norm Siebern and a solo blast by Bill Tuttle tied the game , and single runs in the eighth and ninth gave the Athletics their fifth victory in eight starts .\n",
+      "96: House throws wild With one down in the eighth , Marv Throneberry drew a walk and stole second as Hyde fanned Tuttle .\n",
+      "97: Catcher Frank House 's throw in an effort to nab Throneberry was wide and in the dirt .\n",
+      "98: Then Heywood Sullivan , Kansas City catcher , singled up the middle and Throneberry was across with what proved to be the winning run .\n",
+      "99: Rookie southpaw George Stepanovich relieved Hyde at the start of the ninth and gave up the A 's fifth tally on a walk to second baseman Dick Howser , a wild pitch , and Frank Cipriani 's single under Shortstop Jerry Adair 's glove into center .\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "for (start, end) in rpt.utils.pairwise([0] + TRUE_BKPS):\n",
     "    excerpt = original_text[start:end]\n",
@@ -501,7 +826,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes the `docs` job in the CI : https://github.com/deepcharles/ruptures/actions/runs/3826472378/jobs/6510297491

The underlying reason is that the API of sklearn's [CountVectorizer](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html#sklearn-feature-extraction-text-countvectorizer) has changed (see [here](https://github.com/scikit-learn/scikit-learn/commit/2708aac0348402850f8e5b3176e84b39c6f5917d) for change). 

`get_feature_names` is now deprecated and becomes `get_feature_names_out`. 