### PR TITLE
docs: fix nbconvert command line when building docs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install .[docs]
     - name: Run notebooks
       run: |
-        jupyter nbconvert --inplace --to notebook --ExecutePreprocessor.kernel_name=python --execute $(find ./docs -name '*.ipynb')
+        find ./docs -name '*.ipynb' | xargs -P 3 -I % jupyter nbconvert --inplace --to notebook --ExecutePreprocessor.kernel_name=python --execute %
     - name: Build documentation
       run: |
         mkdocs build

--- a/.github/workflows/publish-doc-to-remote.yml
+++ b/.github/workflows/publish-doc-to-remote.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install .[docs]
     - name: Run notebooks
       run: |
-        jupyter nbconvert --inplace --to notebook --ExecutePreprocessor.kernel_name=python --execute $(find ./docs -name '*.ipynb')
+        find ./docs -name '*.ipynb' | xargs -P 3 -I % jupyter nbconvert --inplace --to notebook --ExecutePreprocessor.kernel_name=python --execute %
     - name: Build documentation
       run: |
         mkdocs build


### PR DESCRIPTION
New version [7.3.0](https://pypi.org/project/nbconvert/7.3.0/) of `nbconvert` makes the `docs` (and probably the `Publish docs online`) CI jobs crash. 
Underlying reason is that for some reasons the `--inplace` option does not work when taking as input several files. 

# Solution

I just used a pipe alongside `xargs` (and bonus bumped the number of process to 3). 
