### PR TITLE
build: use latest gha version for uploading to pypi 

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -99,7 +99,7 @@ jobs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.4.1
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: ${{ secrets.PYPI_USERNAME }}
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This PR uses by default the latest version of [gh-action-pypi-publish](https://github.com/marketplace/actions/pypi-publish). 

Before this PR, version number `v1.4.1` was pinned in the GH workflow file. It caused the upload part of the job to fail (see [here](https://github.com/deepcharles/ruptures/actions/runs/5199616908/jobs/9377675489)). 