### PR TITLE
docs: fix notebook link in docs

### DIFF
--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -43,7 +43,7 @@ def define_env(env):
         filepath = f"{docs_dirs}/{page.file.src_path}"
         binder_link = f"{BINDER_URL}/{repo_name}/{BRANCH}"
         binder_link = f"{binder_link}?filepath={filepath}"
-        download_link = f"{repo_url}blob/{BRANCH}/{filepath}"
+        download_link = f"{repo_url}/blob/{BRANCH}/{filepath}"
         return BINDER_TEMPLATE.format(
             binder_link=binder_link, download_link=download_link
         )


### PR DESCRIPTION
The links in the documentation to the original notebooks are currently broken. This PR introduces the missing `/` to the links:

[Original link](https://github.com/deepcharles/rupturesblob/master/docs/examples/music-segmentation.ipynb):

```https://github.com/deepcharles/rupturesblob/master/docs/examples/music-segmentation.ipynb```

[New link](https://github.com/deepcharles/ruptures/blob/master/docs/examples/music-segmentation.ipynb):

```https://github.com/deepcharles/ruptures/blob/master/docs/examples/music-segmentation.ipynb```