### PR TITLE
ci(codecov): Update run-test.yml

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Update the Codecov version from v2 to v4 because Codecoverage actions are currently failing (e.g. https://github.com/deepcharles/ruptures/actions/runs/9305356366/job/25645080125)