### PR TITLE
ci(codecov): update codecov gha version number

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.5
       # env:
       #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -52,9 +52,9 @@ jobs:
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v3
+      # env:
+      #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.5
+      uses: codecov/codecov-action@v5
       # env:
       #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -53,6 +53,8 @@ jobs:
         python -m pytest --cov --cov-report=xml --cov-report=term:skip-covered
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
Updating the GHA that runs tests and uploads to https://app.codecov.io/gh/deepcharles/ruptures 

Now using `codecov/codecov-action@v4` as mentioned in https://github.com/marketplace/actions/checkout