### PR TITLE
ci(tests): use new version of the coverage uploader

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -57,6 +57,6 @@ jobs:
         files: ./coverage.xml
         flags: unittests
         fail_ci_if_error: true
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: coverage.xml


### PR DESCRIPTION
Use new version of the uploader gha since v2 is not supported anymore: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

It was falling the CI job "coverage", for instance see here for symptoms:  https://github.com/deepcharles/ruptures/actions/runs/13174606396/job/36771046953 