### PR TITLE
docs: correct Latex formatting

### DIFF
--- a/docs/examples/basic-usage.ipynb
+++ b/docs/examples/basic-usage.ipynb
@@ -68,7 +68,7 @@
     "Note that the first four element are change point indexes while the last is simply the number of samples.\n",
     "(This is a technical convention so that functions in `ruptures` always know the length of the signal at hand.)\n",
     "\n",
-    "It is also possible to plot our $\\mathbb{R}^3$-valued signal along with the true change points with the `rpt.display` function.\n",
+    "It is also possible to plot our \\(\\mathbb{R}^3\\)-valued signal along with the true change points with the `rpt.display` function.\n",
     "In the following image, the color changes whenever the mean of the signal shifts."
    ]
   },
@@ -88,22 +88,24 @@
     "## Change point detection\n",
     "We can now perform change point detection, meaning that we find the indexes where the signal mean changes.\n",
     "To that end, we minimize the sum of squared errors when approximating the signal by a piecewise constant signal.\n",
-    "Formally, for a signal $y_0,y_1,\\dots,y_{T-1}$ ($T$ samples), we solve the following optimization problem, over all possible change positions $t_1<t_2<\\dots<t_K$ (where the number $K$ of changes is defined by the user):\n",
+    "Formally, for a signal \\( y_0 , y_1 , \\dots , y_{T-1} \\) (\\( T \\) samples), we solve the following optimization problem, over all possible change positions \\( t_1 < t_2 < \\dots < t_K \\)\n",
+    "where the number \\( K \\) of changes is defined by the user:\n",
     "\n",
-    "$$\n",
-    "\\hat{t}_1, \\hat{t}_2,\\dots,\\hat{t}_K = \\arg\\min_{t_1,\\dots,t_K} V(t_1,t_2,\\dots,t_K)\n",
-    "$$\n",
+    "\\[\n",
+    "    \\hat{t}_1, \\hat{t}_2,\\dots,\\hat{t}_K = \\arg\\min_{t_1,\\dots,t_K} V(t_1,t_2,\\dots,t_K)\n",
+    "\\]\n",
     "\n",
     "with\n",
     "\n",
-    "$$\n",
-    "V(t_1,t_2,\\dots,t_K) := \\sum_{k=0}^K\\sum_{t=t_k}^{t_{k+1}-1} \\|y_t-\\bar{y}_{t_k..t_{k+1}}\\|^2\n",
-    "$$\n",
+    "\\[\n",
+    "    V(t_1,t_2,\\dots,t_K) := \\sum_{k=0}^K\\sum_{t=t_k}^{t_{k+1}-1} \\|y_t-\\bar{y}_{t_k..t_{k+1}}\\|^2\n",
+    "\\]\n",
     "\n",
-    "where $\\bar{y}_{t_k..t_{k+1}}$ is the empirical mean of the sub-signal $y_{t_k}, y_{t_k+1},\\dots,y_{t_{k+1}-1}$.\n",
-    "(By convention $t_0=0$ and $t_{K+1}=T$.)\n",
     "\n",
-    "This optimization is solved with dynamic programming, using the [`Dynp`](../user-guide/detection/dynp.md) class. (More information in the section [What is change point detection?](/what-is-cpd) and the [User guide](/user-guide).)"
+    "where \\( \\bar{y}_{t_k..t_{k+1}} \\) is the empirical mean of the sub-signal \\( y_{t_k}, y_{t_k+1},\\dots,y_{t_{k+1}-1} \\).\n",
+    "(By convention \\( t_0=0 \\) and \\( t_{K+1}=T \\).)\n",
+    "\n",
+    "This optimization is solved with dynamic programming, using the [`Dynp`](../user-guide/detection/dynp.md) class. (More information in the section [What is change point detection?](/what-is-cpd) and the [User guide](/user-guide).)\n"
    ]
   },
   {

--- a/docs/getting-started/basic-usage.ipynb
+++ b/docs/getting-started/basic-usage.ipynb
@@ -68,7 +68,7 @@
     "Note that the first four element are change point indexes while the last is simply the number of samples.\n",
     "(This is a technical convention so that functions in `ruptures` always know the length of the signal at hand.)\n",
     "\n",
-    "It is also possible to plot our $\\mathbb{R}^3$-valued signal along with the true change points with the `rpt.display` function.\n",
+    "It is also possible to plot our \\(\\mathbb{R}^3\\)-valued signal along with the true change points with the `rpt.display` function.\n",
     "In the following image, the color changes whenever the mean of the signal shifts."
    ]
   },
@@ -88,22 +88,24 @@
     "## Change point detection\n",
     "We can now perform change point detection, meaning that we find the indexes where the signal mean changes.\n",
     "To that end, we minimize the sum of squared errors when approximating the signal by a piecewise constant signal.\n",
-    "Formally, for a signal $y_0,y_1,\\dots,y_{T-1}$ ($T$ samples), we solve the following optimization problem, over all possible change positions $t_1<t_2<\\dots<t_K$ (where the number $K$ of changes is defined by the user):\n",
+    "Formally, for a signal \\( y_0 , y_1 , \\dots , y_{T-1} \\) (\\( T \\) samples), we solve the following optimization problem, over all possible change positions \\( t_1 < t_2 < \\dots < t_K \\)\n",
+    "where the number \\( K \\) of changes is defined by the user:\n",
     "\n",
-    "$$\n",
-    "\\hat{t}_1, \\hat{t}_2,\\dots,\\hat{t}_K = \\arg\\min_{t_1,\\dots,t_K} V(t_1,t_2,\\dots,t_K)\n",
-    "$$\n",
+    "\\[\n",
+    "    \\hat{t}_1, \\hat{t}_2,\\dots,\\hat{t}_K = \\arg\\min_{t_1,\\dots,t_K} V(t_1,t_2,\\dots,t_K)\n",
+    "\\]\n",
     "\n",
     "with\n",
     "\n",
-    "$$\n",
-    "V(t_1,t_2,\\dots,t_K) := \\sum_{k=0}^K\\sum_{t=t_k}^{t_{k+1}-1} \\|y_t-\\bar{y}_{t_k..t_{k+1}}\\|^2\n",
-    "$$\n",
+    "\\[\n",
+    "    V(t_1,t_2,\\dots,t_K) := \\sum_{k=0}^K\\sum_{t=t_k}^{t_{k+1}-1} \\|y_t-\\bar{y}_{t_k..t_{k+1}}\\|^2\n",
+    "\\]\n",
     "\n",
-    "where $\\bar{y}_{t_k..t_{k+1}}$ is the empirical mean of the sub-signal $y_{t_k}, y_{t_k+1},\\dots,y_{t_{k+1}-1}$.\n",
-    "(By convention $t_0=0$ and $t_{K+1}=T$.)\n",
     "\n",
-    "This optimization is solved with dynamic programming, using the [`Dynp`](../user-guide/detection/dynp.md) class. (More information in the section [What is change point detection?](/what-is-cpd) and the [User guide](/user-guide).)"
+    "where \\( \\bar{y}_{t_k..t_{k+1}} \\) is the empirical mean of the sub-signal \\( y_{t_k}, y_{t_k+1},\\dots,y_{t_{k+1}-1} \\).\n",
+    "(By convention \\( t_0=0 \\) and \\( t_{K+1}=T \\).)\n",
+    "\n",
+    "This optimization is solved with dynamic programming, using the [`Dynp`](../user-guide/detection/dynp.md) class. (More information in the section [What is change point detection?](/what-is-cpd) and the [User guide](/user-guide).)\n"
    ]
   },
   {

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+  
+  document$.subscribe(() => { 
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+  })

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -10,8 +10,8 @@ window.MathJax = {
       processHtmlClass: "arithmatex"
     }
   };
-  
-  document$.subscribe(() => { 
+
+  document$.subscribe(() => {
     MathJax.startup.output.clearCache()
     MathJax.typesetClear()
     MathJax.texReset()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ plugins:
         - ruptures
       handlers:
         python:
-          selection:
+          options:
             filters:
               - "!^_"  # exclude all members starting with _
               - "^__init__$"  # but always include __init__ modules and methods
@@ -124,6 +124,7 @@ theme:
     - navigation.tabs
     - search.highlight
 extra_javascript:
-  - javascripts/config.js
+  - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
Fix #347 

- changes a few latex delimiters from $ $  to \\( \\) and $$ $$ to \\[ \\].
- change mathjax.js as in [here](https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax)
- fix the unrelated warning about `options` and `selection` in `mkdocs.yml` [(see here)](https://mkdocstrings.github.io/usage/handlers/#selection-options)