### PR TITLE
build: add python 3.13 wheels

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -57,7 +57,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: pp* cp{38,39,310,311,312}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312}-win32
+          CIBW_SKIP: pp* cp{38,39,310,311,312,313}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313}-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310, 311, 312]
+        python: [36, 37, 38, 39, 310, 311, 312, 313]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/deepcharles/ruptures/graphs/commit-activity)
 [![build](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml)
-![python](https://img.shields.io/badge/python-3.8%20|%203.9%20|3.10%20|3.11%20|3.12-blue)
+![python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)
 [![PyPI version](https://badge.fury.io/py/ruptures.svg)](https://badge.fury.io/py/ruptures)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ruptures.svg)](https://anaconda.org/conda-forge/ruptures)
 [![docs](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml)


### PR DESCRIPTION
This pull request updates project configuration and documentation to add support for Python 3.13. The main changes ensure that builds, badges, and matrix strategies now include Python 3.13.

Python 3.13 support and configuration updates:

* Updated Python version badge in `README.md` to include Python 3.13.
* Modified the build matrix in `.github/workflows/upload-to-pypi.yml` to add Python 3.13, ensuring CI runs for this version.
* Updated the `CIBW_SKIP` environment variable in `.github/workflows/upload-to-pypi.yml` to skip building wheels for Python 3.13 on `manylinux_i686` and `win32` platforms, aligning with existing skip logic for other versions.
__________________________________________________________________________________________________________________________

addresses #334 