### PR TITLE
fix: avoids build crash from setup.cfg generating a version file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,13 @@ if __name__ == "__main__":
 
     version_file = os.path.join("src", "ruptures", "version.py")
     if not os.path.exists(version_file):
-        version = get_version(root='.', relative_to=__file__)
+        version = get_version(root=".", relative_to=__file__)
         if not version:
-            raise RuntimeError("Version could not be determined. Ensure you have a valid git tag.")
+            raise RuntimeError(
+                "Version could not be determined. Ensure you have a valid git tag."
+            )
         with open(version_file, "w") as f:
-             f.write(f'__version__ = version = "{version}"\n')
+            f.write(f'__version__ = version = "{version}"\n')
 
     setup(
         ext_modules=cythonize(ext_modules, language_level="3"),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import os
 from setuptools import Extension, setup
+from setuptools_scm import get_version
 
 ext_modules = [
     Extension(
@@ -19,9 +21,16 @@ ext_modules = [
     ),
 ]
 
-
 if __name__ == "__main__":
     from Cython.Build import cythonize
+
+    version_file = os.path.join("src", "ruptures", "version.py")
+    if not os.path.exists(version_file):
+        version = get_version(root='.', relative_to=__file__)
+        if not version:
+            raise RuntimeError("Version could not be determined. Ensure you have a valid git tag.")
+        with open(version_file, "w") as f:
+             f.write(f'__version__ = version = "{version}"\n')
 
     setup(
         ext_modules=cythonize(ext_modules, language_level="3"),


### PR DESCRIPTION
This pull request updates the `setup.py` build process to automatically generate a version file for the package if it does not already exist. This improves version management and ensures the package version is always consistent with the git tags or with the forced version `SETUPTOOLS_SCM_PRETEND_VERSION`.

Build and versioning improvements:

* Added logic to check for the existence of `src/ruptures/version.py` and, if missing, automatically generate it using `setuptools_scm` to extract the version from git tags. This ensures the package always has an up-to-date version file.
* Imported `os` and `get_version` from `setuptools_scm` to support the new version file generation logic.