### PR TITLE
ci(upload-pypi): upgrade version of artefact upload action

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -9,11 +9,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.13'
     - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
         sudo apt-get install libsndfile1-dev

--- a/.github/workflows/publish-doc-to-remote.yml
+++ b/.github/workflows/publish-doc-to-remote.yml
@@ -10,11 +10,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.13'
     - name: Install sndfile library # for librose, see https://github.com/deepcharles/ruptures/pull/121
       run: |
         sudo apt-get install libsndfile1-dev

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,13 +19,13 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install ruptures
@@ -39,11 +39,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.13'
     - name: Install ruptures
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -58,7 +58,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: pp* cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314,314t}-win32
+          CIBW_SKIP: cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314,314t}-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37, 38, 39, 310, 311, 312, 313]
+        python: [38, 39, 310, 311, 312, 313]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -23,9 +23,9 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install deps
@@ -46,10 +46,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -80,10 +80,10 @@ jobs:
             arch: aarch64
             platform_id: manylinux_aarch64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [38, 39, 310, 311, 312, 313,314]
+        python: [39, 310, 311, 312, 313, 314]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -58,7 +58,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: pp* cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314}-win32
+          CIBW_SKIP: pp* cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314,314t}-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -m build --sdist
       - uses: actions/upload-artifact@v4
         with:
-          name: sdist
+          name: cibw-sdist
           path: dist/*.tar.gz
       - name: Check metadata
         run: twine check dist/*
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: cibw-wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
 
   build_aarch64_wheels:
@@ -97,7 +97,7 @@ jobs:
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: aarch64_wheels
+          name: cibw-aarch64_wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
 
   upload_all:
@@ -106,16 +106,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v5
         with:
-          name: sdist
+          pattern: cibw-*
           path: dist
-      - uses: actions/download-artifact@v5
-        with:
-          name: wheels
-          path: dist
-      - uses: actions/download-artifact@v5
-        with:
-          name: aarch64_wheels
-          path: dist
+          merge-multiple: true
       - name: Publish to PyPI
         if: ${{ github.event.inputs.uploadToPyPI == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
   build_aarch64_wheels:
@@ -97,7 +97,7 @@ jobs:
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-aarch64_wheels-${{ matrix.os }}
+          name: cibw-aarch64_wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
   upload_all:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -101,7 +101,7 @@ jobs:
     needs: [build_wheels, build_aarch64_wheels, make_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install deps
         run: python -m pip install build twine
       - name: Build SDist

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -6,10 +6,10 @@ on:
       overrideVersion:
         description: Manually force a version
       uploadToPyPI:
-          description: Upload to PyPI
-          required: false
-          default: false
-          type: boolean
+        description: Upload to PyPI
+        required: false
+        default: false
+        type: boolean
 
 env:
   CIBW_BUILD_VERBOSITY: 3
@@ -34,6 +34,7 @@ jobs:
         run: python -m build --sdist
       - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
       - name: Check metadata
         run: twine check dist/*
@@ -65,6 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels
           path: wheelhouse/*.whl
 
   build_aarch64_wheels:
@@ -95,6 +97,7 @@ jobs:
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
       - uses: actions/upload-artifact@v4
         with:
+          name: aarch64_wheels
           path: wheelhouse/*.whl
 
   upload_all:
@@ -103,7 +106,15 @@ jobs:
     steps:
       - uses: actions/download-artifact@v5
         with:
-          name: artifact
+          name: sdist
+          path: dist
+      - uses: actions/download-artifact@v5
+        with:
+          name: wheels
+          path: dist
+      - uses: actions/download-artifact@v5
+        with:
+          name: aarch64_wheels
           path: dist
       - name: Publish to PyPI
         if: ${{ github.event.inputs.uploadToPyPI == 'true' }}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -58,7 +58,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: pp* cp{38,39,310,311,312,313}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313}-win32
+          CIBW_SKIP: pp* cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314}-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [38, 39, 310, 311, 312, 313]
+        python: [38, 39, 310, 311, 312, 313,314]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -32,7 +32,7 @@ jobs:
         run: python -m pip install build twine
       - name: Build SDist
         run: python -m build --sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
       - name: Check metadata
@@ -63,7 +63,7 @@ jobs:
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
           CIBW_ARCHS_MACOS: x86_64 arm64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
 
@@ -93,7 +93,7 @@ jobs:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
 
@@ -101,7 +101,7 @@ jobs:
     needs: [build_wheels, build_aarch64_wheels, make_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: artifact
           path: dist

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -50,7 +50,8 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v6
-
+        with:
+          python-version: "3.13"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/deepcharles/ruptures/graphs/commit-activity)
 [![build](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml)
-![python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)
+![python](https://img.shields.io/badge/python-%203.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13-blue)
 [![PyPI version](https://badge.fury.io/py/ruptures.svg)](https://badge.fury.io/py/ruptures)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ruptures.svg)](https://anaconda.org/conda-forge/ruptures)
 [![docs](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >= 3.8
+python_requires = >= 3.9
 install_requires =
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >=3.9, <=3.13
+python_requires = >=3.9, <3.14
 install_requires =
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >= 3.9
+python_requires = >=3.9, <=3.13
 install_requires =
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >= 3.6
+python_requires = >= 3.8
 install_requires =
     numpy
     scipy


### PR DESCRIPTION
An error is thrown when uploading an artefact (`actions/upload-artifact`) because the version is too old

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

#### Edit 

Everything broke after bumping the version, so I ended up changing more things.

Summary of changes:
- only build wheels for python >=3.8 by modifying `setup.cfg` (there was an error when installing scipy for py37 on win_amd64)
- add wheels for py314 and py314t (whatever this is)
- skip wheels for win32 for py314 and py314t
- update version of `actions/upload-artifact`, and giving a specific name for each artifact to avoid name collision 
- update all possible versions of python and gha (setup-python, checkout, setup-quemu)
- Remove py38 and py314 from tests

My changes are mostly based [on this guide](https://learn.scientific-python.org/development/guides/gha-wheels/)