### PR TITLE
ci(build-wheel): remove py314 from wheels (aarch64)

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [39, 310, 311, 312, 313, 314]
+        python: [39, 310, 311, 312, 313]
         include:
           - os: ubuntu-latest
             arch: aarch64


### PR DESCRIPTION
Forgot to remove wheels for py314 (aarch64) 