### PR TITLE
chore(build): fix the build for pypi

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [39, 310, 311, 312, 313]
+        python: [39, 310, 311, 312, 313, 314]
         include:
           - os: ubuntu-latest
             arch: aarch64
@@ -101,21 +101,21 @@ jobs:
           name: cibw-aarch64_wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
-  # upload_all:
-  #   needs: [build_wheels, build_aarch64_wheels, make_sdist]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/download-artifact@v5
-  #       with:
-  #         pattern: cibw-*
-  #         path: dist
-  #         merge-multiple: true
-  #     - name: Publish to PyPI
-  #       if: ${{ github.event.inputs.uploadToPyPI == 'true' }}
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         user: ${{ secrets.PYPI_USERNAME }}
-  #         password: ${{ secrets.PYPI_PASSWORD }}
-  #     - name: Skipped PyPI Upload
-  #       if: ${{ github.event.inputs.uploadToPyPI != 'true' }}
-  #       run: echo "Upload to PyPI was skipped due to workflow input."
+  upload_all:
+    needs: [build_wheels, build_aarch64_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        if: ${{ github.event.inputs.uploadToPyPI == 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+      - name: Skipped PyPI Upload
+        if: ${{ github.event.inputs.uploadToPyPI != 'true' }}
+        run: echo "Upload to PyPI was skipped due to workflow input."

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install deps
         run: python -m pip install build twine
       - name: Build SDist
@@ -51,7 +51,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [39, 310, 311, 312, 313, 314]
+        python: [39, 310, 311, 312, 313]
         include:
           - os: ubuntu-latest
             arch: aarch64
@@ -101,21 +101,21 @@ jobs:
           name: cibw-aarch64_wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
-  upload_all:
-    needs: [build_wheels, build_aarch64_wheels, make_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v5
-        with:
-          pattern: cibw-*
-          path: dist
-          merge-multiple: true
-      - name: Publish to PyPI
-        if: ${{ github.event.inputs.uploadToPyPI == 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
-      - name: Skipped PyPI Upload
-        if: ${{ github.event.inputs.uploadToPyPI != 'true' }}
-        run: echo "Upload to PyPI was skipped due to workflow input."
+  # upload_all:
+  #   needs: [build_wheels, build_aarch64_wheels, make_sdist]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v5
+  #       with:
+  #         pattern: cibw-*
+  #         path: dist
+  #         merge-multiple: true
+  #     - name: Publish to PyPI
+  #       if: ${{ github.event.inputs.uploadToPyPI == 'true' }}
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         user: ${{ secrets.PYPI_USERNAME }}
+  #         password: ${{ secrets.PYPI_PASSWORD }}
+  #     - name: Skipped PyPI Upload
+  #       if: ${{ github.event.inputs.uploadToPyPI != 'true' }}
+  #       run: echo "Upload to PyPI was skipped due to workflow input."

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - name: Install deps
         run: python -m pip install build twine
       - name: Build SDist
@@ -51,7 +51,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [39, 310, 311, 312, 313, 314]
+        python: [39, 310, 311, 312, 313]
         include:
           - os: ubuntu-latest
             arch: aarch64


### PR DESCRIPTION
The build for aarch64 and python v3.14 fails : https://github.com/deepcharles/ruptures/actions/runs/19742465073 

This PR removes this specific build. 

Other builds work. 