### PR TITLE
chore: fix declared python version dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >=3.9, <=3.14
+python_requires = >=3.9, <3.15
 install_requires =
     numpy
     scipy


### PR DESCRIPTION
Hi, 
in #361 you merged support for python 3.14, however the compatibility was declared for version `<=3.14` therefore it is only compatible with `3.14.0` and not any later patch level (like the current `3.14.3`). This simply declares compatibility with all further patch level releases of Py 3.14