### PR TITLE
Drop Python 3.9 support and update dev tooling

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,7 +19,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -59,7 +59,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly building PyPI wheels for specific configurations
-          CIBW_SKIP: cp{38,39,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,39,310,311,312,313,314,314t}-win32
+          CIBW_SKIP: cp{38,310,311,312,313,314}-manylinux_i686 *-musllinux_* cp{38,310,311,312,313,314,314t}-win32
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [39, 310, 311, 312, 313, 314]
+        python: [310, 311, 312, 313, 314]
         include:
           - os: ubuntu-latest
             arch: aarch64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 25.9.0
+  rev: 25.12.0
   hooks:
     - id: black
       language_version: python3
@@ -19,7 +19,7 @@ repos:
   hooks:
     - id: python-no-eval  # A quick check for the eval() built-in function.
 - repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.7 # Don't autoupdate until https://github.com/PyCQA/docformatter/issues/293 is fixed
+  rev: v1.7.8
   hooks:
     - id: docformatter
       exclude: mkdocs_macros.py
@@ -30,7 +30,7 @@ repos:
     - id: flake8
       # additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-spellcheck, flake8-import-order]
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.8.1
+  rev: 0.8.2
   hooks:
     - id: nbstripout
 -   repo: https://github.com/asottile/blacken-docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/deepcharles/ruptures/graphs/commit-activity)
 [![build](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/run-test.yml)
-![python](https://img.shields.io/badge/python-%203.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13|%203.14%20-blue)
+![python](https://img.shields.io/badge/python-%203.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14%20-blue)
 [![PyPI version](https://badge.fury.io/py/ruptures.svg)](https://badge.fury.io/py/ruptures)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ruptures.svg)](https://anaconda.org/conda-forge/ruptures)
 [![docs](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml/badge.svg)](https://github.com/deepcharles/ruptures/actions/workflows/check-docs.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "Cython>=0.28.5",
     "setuptools_scm[toml]>=3.4",  # https://scikit-hep.org/developer/packaging#git-tags-official-pypa-method
-    "oldest-supported-numpy",  # https://github.com/scipy/oldest-supported-numpy
+    "numpy>=2.0.0",  # https://numpy.org/doc/stable/dev/depending_on_numpy.html
     "scipy>=0.19.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,11 @@ keywords =
     time series
 classifiers =
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: Mathematics
     Intended Audience :: Science/Research
@@ -30,7 +35,7 @@ classifiers =
 [options]
 zip_safe = True
 include_package_data = True
-python_requires = >=3.9, <=3.14
+python_requires = >=3.10
 install_requires =
     numpy
     scipy

--- a/src/ruptures/costs/costautoregressive.py
+++ b/src/ruptures/costs/costautoregressive.py
@@ -24,13 +24,14 @@ class CostAR(BaseCost):
         self.order = order
 
     def fit(self, signal):
-        """Set parameters of the instance. The signal must be 1D.
+        """Set parameters of the instance.
 
-        Args:
-            signal (array): 1d signal. Shape (n_samples, 1) or (n_samples,).
+        The signal must be 1D.
+                Args:
+                    signal (array): 1d signal. Shape (n_samples, 1) or (n_samples,).
 
-        Returns:
-            self: the current object
+                Returns:
+                    self: the current object
         """
         self.signal = deepcopy(signal)
         if signal.ndim == 1:

--- a/src/ruptures/costs/costlinear.py
+++ b/src/ruptures/costs/costlinear.py
@@ -18,8 +18,9 @@ class CostLinear(BaseCost):
         self.min_size = 2
 
     def fit(self, signal) -> "CostLinear":
-        """Set parameters of the instance. The first column contains the
-        observed variable. The other columns contains the covariates.
+        """Set parameters of the instance.
+
+        The first column contains the observed variable. The other columns contains the covariates.
 
         Args:
             signal (array): signal of shape (n_samples, n_regressors+1)

--- a/src/ruptures/detection/kernelcpd.py
+++ b/src/ruptures/detection/kernelcpd.py
@@ -78,23 +78,24 @@ class KernelCPD(BaseEstimator):
         return self
 
     def predict(self, n_bkps=None, pen=None):
-        """Return the optimal breakpoints. Must be called after the fit method.
+        """Return the optimal breakpoints.
 
-        The breakpoints are associated with the signal passed to
-        [`fit()`][ruptures.detection.kernelcpd.KernelCPD.fit].
+        Must be called after the fit method.
+                The breakpoints are associated with the signal passed to
+                [`fit()`][ruptures.detection.kernelcpd.KernelCPD.fit].
 
-        Args:
-            n_bkps (int, optional): Number of change points. Defaults to None.
-            pen (float, optional): penalty value (>0). Defaults to None. Not considered
-                if n_bkps is not None.
+                Args:
+                    n_bkps (int, optional): Number of change points. Defaults to None.
+                    pen (float, optional): penalty value (>0). Defaults to None. Not considered
+                        if n_bkps is not None.
 
-        Raises:
-            AssertionError: if `pen` or `n_bkps` is not strictly positive.
-            BadSegmentationParameters: in case of impossible segmentation
-                configuration
+                Raises:
+                    AssertionError: if `pen` or `n_bkps` is not strictly positive.
+                    BadSegmentationParameters: in case of impossible segmentation
+                        configuration
 
-        Returns:
-            list[int]: sorted list of breakpoints
+                Returns:
+                    list[int]: sorted list of breakpoints
         """
         # Our KernelCPD implementation with Pelt implies that we have at least one change point
         # raise an exception in case of impossible segmentation configuration

--- a/src/ruptures/exceptions.py
+++ b/src/ruptures/exceptions.py
@@ -1,6 +1,8 @@
 """The `ruptures.exceptions` module includes all custom warnings and error
 classes used across ruptures."""
 
+__all__ = ["BadSegmentationParameters", "NotEnoughPoints"]
+
 
 class NotEnoughPoints(Exception):
     """Raise this exception when there is not enough point to calculate a cost

--- a/src/ruptures/metrics/hamming.py
+++ b/src/ruptures/metrics/hamming.py
@@ -4,8 +4,9 @@ from ruptures.metrics.randindex import randindex
 
 
 def hamming(bkps1, bkps2):
-    """Modified Hamming distance for partitions. For all pair of points (x, y),
-    x != y, the functions computes the number of times the two partitions
+    """Modified Hamming distance for partitions.
+
+    For all pair of points (x, y), x != y, the functions computes the number of times the two partitions
     disagree. The result is scaled to be within 0 and 1.
 
     Args:

--- a/src/ruptures/metrics/sanity_check.py
+++ b/src/ruptures/metrics/sanity_check.py
@@ -1,5 +1,7 @@
 """Helper function to check if two breakpoints list are comparable."""
 
+__all__ = ["BadPartitions", "sanity_check"]
+
 
 class BadPartitions(Exception):
     """Exception raised when the partition is bad."""


### PR DESCRIPTION
## Summary

- Python 3.9 is no longer supported or tested. Minimum version is now 3.10.
- Replaced `oldest-supported-numpy` with `numpy>=2.0.0` as a build dependency.
- Upgraded `docformatter` pre-commit hook from v1.7.7 to v1.7.8, which fixes
installation on Python 3.14 (see PyCQA/docformatter#340).

## Notes

Added `__all__` to `ruptures.exceptions` and `ruptures.metrics.sanity_check`
to resolve a formatting conflict between `black` and `docformatter` that
appeared when a module docstring is immediately followed by a class definition.