### PR TITLE
fix: discard cached gram matrix when refitting CostRbf/CostCosine

### DIFF
--- a/src/ruptures/costs/costcosine.py
+++ b/src/ruptures/costs/costcosine.py
@@ -43,6 +43,11 @@ class CostCosine(BaseCost):
             self.signal = signal.reshape(-1, 1)
         else:
             self.signal = signal
+
+        # The gram matrix depends on the signal; discard the one computed for
+        # a previously fitted signal.
+        self._gram = None
+
         return self
 
     def error(self, start: int, end: int) -> float:

--- a/src/ruptures/costs/costrbf.py
+++ b/src/ruptures/costs/costrbf.py
@@ -19,6 +19,7 @@ class CostRbf(BaseCost):
         """Initialize the object."""
         self.min_size = 1
         self.gamma = gamma
+        self.has_custom_gamma = False if gamma is None else True
         self._gram = None
 
     @property
@@ -55,6 +56,12 @@ class CostRbf(BaseCost):
             self.signal = signal.reshape(-1, 1)
         else:
             self.signal = signal
+
+        # The gram matrix and the median-heuristic gamma depend on the signal;
+        # discard values computed for a previously fitted signal.
+        self._gram = None
+        if self.has_custom_gamma is False:
+            self.gamma = None
 
         # If gamma is none, set it using the median heuristic.
         # This heuristic involves computing the gram matrix which is lazy loaded

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -258,8 +258,8 @@ def test_costs_refit_matches_fresh_fit(cost_name):
 
 
 def test_costrbf_refit_gamma():
-    """The median-heuristic gamma is recomputed for each fitted signal, while
-    a user-supplied gamma is kept (#372)."""
+    """The median-heuristic gamma is recomputed for each fitted signal, while a
+    user-supplied gamma is kept (#372)."""
     signal1, _ = pw_constant(n_features=1, noise_std=1, seed=111111)
     signal2, _ = pw_constant(n_features=1, noise_std=3, seed=222222)
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from ruptures import Binseg
-from ruptures.costs import CostLinear, CostNormal, cost_factory
+from ruptures.costs import CostLinear, CostNormal, CostRbf, cost_factory
 from ruptures.costs.costml import CostMl
 from ruptures.datasets import pw_constant
 from ruptures.exceptions import NotEnoughPoints
@@ -237,3 +237,58 @@ def test_costl2_small_data():
         "got {computed_break_dict}.",
     )
     assert expected_break_dict == computed_break_dict, err_msg
+
+
+@pytest.mark.parametrize("cost_name", cost_names)
+def test_costs_refit_matches_fresh_fit(cost_name):
+    """Refitting a cost on a new signal must not reuse state cached from the
+    previous signal (#372)."""
+    signal1, _ = pw_constant(n_features=1, noise_std=1, seed=111111)
+    signal2, bkps2 = pw_constant(n_features=1, noise_std=1, seed=222222)
+
+    reused = cost_factory(cost_name)
+    reused.fit(signal1)
+    reused.error(10, 50)
+    reused.fit(signal2)
+
+    fresh = cost_factory(cost_name)
+    fresh.fit(signal2)
+
+    assert reused.sum_of_costs(bkps2) == pytest.approx(fresh.sum_of_costs(bkps2))
+
+
+def test_costrbf_refit_gamma():
+    """The median-heuristic gamma is recomputed for each fitted signal, while
+    a user-supplied gamma is kept (#372)."""
+    signal1, _ = pw_constant(n_features=1, noise_std=1, seed=111111)
+    signal2, _ = pw_constant(n_features=1, noise_std=3, seed=222222)
+
+    reused = CostRbf()
+    reused.fit(signal1)
+    reused.fit(signal2)
+    fresh = CostRbf()
+    fresh.fit(signal2)
+    assert reused.gamma == pytest.approx(fresh.gamma)
+
+    custom = CostRbf(gamma=0.5)
+    custom.fit(signal1)
+    custom.fit(signal2)
+    assert custom.gamma == 0.5
+
+
+@pytest.mark.parametrize("cost_name", ["rbf", "cosine"])
+def test_detection_refit_matches_fresh_fit(cost_name):
+    """Reusing a detection instance on a second signal gives the same
+    breakpoints as a fresh instance (#372)."""
+    signal1, _ = pw_constant(n_features=1, noise_std=1, seed=111111)
+    signal2, _ = pw_constant(n_features=1, noise_std=1, seed=222222)
+
+    reused = Binseg(model=cost_name)
+    reused.fit(signal1)
+    reused.predict(n_bkps=3)
+    reused.fit(signal2)
+
+    fresh = Binseg(model=cost_name)
+    fresh.fit(signal2)
+
+    assert reused.predict(n_bkps=3) == fresh.predict(n_bkps=3)


### PR DESCRIPTION
Closes #372.

`CostRbf` and `CostCosine` compute their Gram matrix lazily and cache it in `self._gram`, but `fit()` never invalidates the cache. Detection estimators create the cost object once in `__init__` and call `cost.fit(signal)` on every fit, so refitting the same estimator on a different signal silently reuses the previous signal's Gram matrix:

```python
m = rpt.Pelt(model="rbf")
m.fit(s1).predict(pen=3)  # [50, 100]
m.fit(s2).predict(pen=3)  # [50, 100]  <- stale; a fresh instance gives [30, 100]
```

For `CostRbf` there is a second layer: when `gamma=None`, the median-heuristic gamma is derived inside the `gram` property and stays pinned to the first signal, so resetting the cache alone is not enough.

`fit()` now discards `_gram` and re-derives the heuristic gamma per signal, keeping a user-supplied gamma — the same pattern `CostMl` already uses with `has_custom_metric`.

Tests: a parametrized refit-equals-fresh-fit check over all cost models, a gamma re-derivation/persistence test, and an estimator-level check for `rbf`/`cosine` (5 of these fail without the fix). Note: #369 touches `costrbf.py` for memory optimization but does not address this — its `fit` also keeps the cached state.
