### PR TITLE
fix(metrics): handle single-segment partitions in hausdorff and meantime

### DIFF
--- a/src/ruptures/metrics/hausdorff.py
+++ b/src/ruptures/metrics/hausdorff.py
@@ -13,11 +13,19 @@ def hausdorff(bkps1, bkps2):
         bkps2 (list): list of the last index of each regime.
 
     Returns:
-        float: Hausdorff distance.
+        float: Hausdorff distance.  Returns ``np.inf`` when one partition
+        has no intermediate changepoints (i.e. it predicts a single segment)
+        and the other does.
     """
     sanity_check(bkps1, bkps2)
     bkps1_arr = np.array(bkps1[:-1]).reshape(-1, 1)
     bkps2_arr = np.array(bkps2[:-1]).reshape(-1, 1)
+    if bkps1_arr.size == 0 or bkps2_arr.size == 0:
+        # If one partition has no intermediate changepoints and the other does,
+        # the sets are not comparable; return infinity by convention.
+        if bkps1_arr.size == 0 and bkps2_arr.size == 0:
+            return 0.0
+        return np.inf
     pw_dist = cdist(bkps1_arr, bkps2_arr)
     res = max(pw_dist.min(axis=0).max(), pw_dist.min(axis=1).max())
     return res

--- a/src/ruptures/metrics/timeerror.py
+++ b/src/ruptures/metrics/timeerror.py
@@ -17,11 +17,18 @@ def meantime(true_bkps, my_bkps):
             partition)
 
     Returns:
-        float: mean time error.
+        float: mean time error.  Returns ``np.inf`` when ``my_bkps`` contains
+        no intermediate changepoints (i.e. it predicts a single segment) but
+        ``true_bkps`` does.
     """
     sanity_check(true_bkps, my_bkps)
     true_bkps_arr = np.array(true_bkps[:-1]).reshape(-1, 1)
     my_bkps_arr = np.array(my_bkps[:-1]).reshape(-1, 1)
+    if my_bkps_arr.size == 0 or true_bkps_arr.size == 0:
+        # At least one partition has no intermediate changepoints.
+        if my_bkps_arr.size == 0 and true_bkps_arr.size == 0:
+            return 0.0
+        return np.inf
     pw_dist = cdist(true_bkps_arr, my_bkps_arr)
 
     dist_from_true = pw_dist.min(axis=0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -51,7 +51,8 @@ def test_precision_recall(b_mb, margin):
 
 
 def test_hausdorff_empty_intermediate_bkps():
-    """hausdorff must not crash when a partition has no intermediate breakpoints."""
+    """Hausdorff must not crash when a partition has no intermediate
+    breakpoints."""
     # Both no intermediate breakpoints -> distance 0
     assert hausdorff([500], [500]) == 0.0
     # One side empty, the other not -> infinity
@@ -62,7 +63,8 @@ def test_hausdorff_empty_intermediate_bkps():
 
 
 def test_meantime_empty_intermediate_bkps():
-    """meantime must not crash when a partition has no intermediate breakpoints."""
+    """Meantime must not crash when a partition has no intermediate
+    breakpoints."""
     # Both no intermediate breakpoints -> distance 0
     assert meantime([500], [500]) == 0.0
     # One side empty -> infinity

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -50,6 +50,28 @@ def test_precision_recall(b_mb, margin):
     p, r = precision_recall(b, [b[-1]], margin=margin)
 
 
+def test_hausdorff_empty_intermediate_bkps():
+    """hausdorff must not crash when a partition has no intermediate breakpoints."""
+    # Both no intermediate breakpoints -> distance 0
+    assert hausdorff([500], [500]) == 0.0
+    # One side empty, the other not -> infinity
+    import math
+
+    assert math.isinf(hausdorff([500], [200, 500]))
+    assert math.isinf(hausdorff([200, 500], [500]))
+
+
+def test_meantime_empty_intermediate_bkps():
+    """meantime must not crash when a partition has no intermediate breakpoints."""
+    # Both no intermediate breakpoints -> distance 0
+    assert meantime([500], [500]) == 0.0
+    # One side empty -> infinity
+    import math
+
+    assert math.isinf(meantime([500], [200, 500]))
+    assert math.isinf(meantime([200, 500], [500]))
+
+
 @pytest.mark.parametrize(
     "metric", [hamming, hausdorff, meantime, precision_recall, randindex]
 )


### PR DESCRIPTION
## Bug

`hausdorff()` and `meantime()` crash with `ValueError` when either
partition contains no intermediate breakpoints (i.e. a single-segment
prediction or ground truth):

```python
>>> import ruptures as rpt
>>> rpt.hausdorff([100], [50, 100])
ValueError: zero-size array to reduction operation minimum which has no identity

>>> rpt.meantime([50, 100], [100])
ValueError: zero-size array to reduction operation minimum which has no identity
```

Both functions call `scipy.spatial.distance.cdist()` on the arrays of
intermediate breakpoints and then take `.min()` / `.max()` of the result.
When one array is empty (no intermediate breakpoints), `cdist` returns a
zero-row or zero-column matrix and `numpy` cannot take the min/max of an
empty axis.

The `sanity_check()` passes for these inputs (both lists end with the same
index), so callers have no way to anticipate the crash.

## Fix

Short-circuit before `cdist` when either intermediate-breakpoint array is
empty:

- Both empty (both single-segment) → distance `0.0`
- One empty, one not → distance `np.inf` (incomparable sets, by convention)

## Tests

Two new parametrized tests verify the edge cases for `hausdorff` and
`meantime` directly.  All 20 tests pass.